### PR TITLE
Rolling UX updates

### DIFF
--- a/.local-automation/README.md
+++ b/.local-automation/README.md
@@ -1,0 +1,15 @@
+# UX-only workflow
+
+This folder mirrors the rolling UX workflow used in the notifications repo.
+
+Expected repo setup:
+- working branch: `ux-only`
+- base branch: `main`
+- rolling pull request: `ux-only` -> `main`
+- labels: `enhancement`, `design`, `github-pages`, `codex-automation`
+
+Main scripts:
+- `run_ux_polish.sh`: runs a bounded Codex UX pass, then syncs the rolling PR and tracking issue
+- `merge_open_prs.sh`: merges mergeable open PRs and closes linked issues
+
+These scripts assume the folder is a real Git checkout of `v-labs-core/v-labs-core.github.io`.

--- a/.local-automation/merge_open_prs.sh
+++ b/.local-automation/merge_open_prs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$WORKSPACE"
+
+if [[ ! -d .git && ! -f .git ]]; then
+  echo "Not a Git workspace: $WORKSPACE"
+  exit 1
+fi
+
+gh auth status >/dev/null
+
+prs_json="$(gh pr list --state open --json number,headRefName,baseRefName,url,mergeStateStatus --limit 100)"
+
+if [[ "$prs_json" == "[]" ]]; then
+  echo "No open PRs to process."
+  exit 0
+fi
+
+while IFS=$'\t' read -r pr_number head_branch base_branch pr_url merge_state; do
+  [[ -z "$pr_number" ]] && continue
+
+  if [[ "$merge_state" == "CLEAN" || "$merge_state" == "UNSTABLE" || "$merge_state" == "HAS_HOOKS" ]]; then
+    gh pr merge "$pr_number" --merge --delete-branch=false
+
+    issue_numbers="$(gh issue list --state open --json number,body --limit 100 --jq '.[] | select((.body // "") | contains("PR #'"$pr_number"'")) | .number' 2>/dev/null || true)"
+    while IFS= read -r issue_number; do
+      [[ -z "$issue_number" ]] && continue
+      gh issue close "$issue_number" --comment "Completed in merged PR #${pr_number}: ${pr_url}" >/dev/null 2>&1 || true
+    done <<< "$issue_numbers"
+  else
+    echo "Skipping PR #${pr_number} with merge state ${merge_state}"
+  fi
+done < <(
+  echo "$prs_json" | python3 - <<'PY'
+import json,sys
+for pr in json.load(sys.stdin):
+    print("\t".join([
+        str(pr.get("number","")),
+        pr.get("headRefName",""),
+        pr.get("baseRefName",""),
+        pr.get("url",""),
+        pr.get("mergeStateStatus",""),
+    ]))
+PY
+)

--- a/.local-automation/run_ux_polish.sh
+++ b/.local-automation/run_ux_polish.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROMPT_FILE="$SCRIPT_DIR/ux_polish_prompt.txt"
+SUMMARY_FILE="$SCRIPT_DIR/last_run_summary.txt"
+CODEX_BIN="${CODEX_BIN:-/Users/mrv/.nvm/versions/node/v24.12.0/bin/codex}"
+PR_TITLE="Rolling UX updates"
+PR_LABELS=(enhancement design github-pages codex-automation)
+
+require_gh() {
+  command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1
+}
+
+extract_pr_number() {
+  local value="$1"
+  if [[ "$value" =~ /pull/([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  if [[ "$value" =~ \#([0-9]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  return 1
+}
+
+ensure_pull_request() {
+  local existing_pr
+  existing_pr="$(gh pr list --head ux-only --base main --state open --json number,url --jq '.[0] | "#\(.number) \(.url)"' 2>/dev/null || true)"
+
+  if [[ -n "$existing_pr" && "$existing_pr" != "null" ]]; then
+    PR_NUMBER="$(extract_pr_number "$existing_pr" || true)"
+    PR_URL="${existing_pr##* }"
+  else
+    PR_URL="$(gh pr create --base main --head ux-only --title "$PR_TITLE" --body "This PR tracks rolling UX-only improvements from the \`ux-only\` branch.")"
+    PR_NUMBER="$(extract_pr_number "$PR_URL" || true)"
+  fi
+
+  for label in "${PR_LABELS[@]}"; do
+    gh pr edit "$PR_NUMBER" --add-label "$label" >/dev/null 2>&1 || true
+  done
+}
+
+ensure_tracking_issue() {
+  local commit_subject="$1"
+
+  local existing_issue
+  existing_issue="$(gh issue list --state open --json number,title,url,body --limit 100 --jq '.[] | select((.body // "") | contains("PR #'"$PR_NUMBER"'")) | "#\(.number) \(.url)"' 2>/dev/null || true)"
+  if [[ -n "$existing_issue" && "$existing_issue" != "null" ]]; then
+    return 0
+  fi
+
+  local issue_body
+  issue_body="$(cat <<BODY
+This issue tracks the UX update in PR #${PR_NUMBER}.
+
+Focus:
+- ${commit_subject}
+
+This issue stays open until PR #${PR_NUMBER} is merged.
+BODY
+)"
+
+  gh issue create \
+    --title "$commit_subject" \
+    --body "$issue_body" \
+    --label "${PR_LABELS[0]}" \
+    --label "${PR_LABELS[1]}" \
+    --label "${PR_LABELS[2]}" \
+    --label "${PR_LABELS[3]}" >/dev/null
+}
+
+main() {
+  cd "$WORKSPACE"
+
+  if [[ ! -d .git && ! -f .git ]]; then
+    echo "Not a Git workspace: $WORKSPACE"
+    exit 1
+  fi
+
+  if [[ "$(git branch --show-current)" != "ux-only" ]]; then
+    echo "Expected branch ux-only"
+    exit 1
+  fi
+
+  if [[ -n "$(git status --porcelain)" ]]; then
+    echo "Working tree is not clean"
+    exit 1
+  fi
+
+  require_gh
+  git fetch --all --prune
+  git reset --hard origin/ux-only
+  git rebase origin/main
+
+  "$CODEX_BIN" exec \
+    --full-auto \
+    --cd "$WORKSPACE" \
+    --sandbox workspace-write \
+    --output-last-message "$SUMMARY_FILE" \
+    - < "$PROMPT_FILE"
+
+  git fetch origin ux-only
+
+  local remote_sha commit_subject
+  remote_sha="$(git rev-parse origin/ux-only)"
+  commit_subject="$(git log -1 --pretty=%s "$remote_sha")"
+
+  ensure_pull_request
+  ensure_tracking_issue "$commit_subject"
+
+  echo "UX workflow synced for ${remote_sha}"
+}
+
+main "$@"

--- a/.local-automation/ux_polish_prompt.txt
+++ b/.local-automation/ux_polish_prompt.txt
@@ -1,0 +1,8 @@
+Review the current website and make one bounded, public-facing UX improvement on the `ux-only` branch.
+
+Rules:
+- Keep the change static-site compatible.
+- Focus on visible UX, layout, visual clarity, copy polish, responsiveness, accessibility, or branding.
+- Avoid backend work.
+- Keep the change small enough for a rolling PR.
+- After the change, commit it to `ux-only` with a concise message and push it.

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,13 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
-    <linearGradient id="g" x1="0%" x2="100%" y1="0%" y2="100%">
-      <stop offset="0%" stop-color="#4ccfc5" />
-      <stop offset="100%" stop-color="#8be7da" />
+    <linearGradient id="bg" x1="8%" y1="6%" x2="92%" y2="94%">
+      <stop offset="0%" stop-color="#7de7dc" />
+      <stop offset="100%" stop-color="#1fabb3" />
+    </linearGradient>
+    <linearGradient id="shine" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.78" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="18" fill="url(#g)" />
-  <path
-    d="M17 16h7.5l7.6 22.7L39.7 16h7.3L35.5 48h-6.8L17 16Zm28.4 0H53v25.6h-11v6.4h-7.6V16Z"
-    fill="#ffffff"
-  />
+  <rect width="64" height="64" rx="18" fill="url(#bg)" />
+  <path d="M14 13h36c-4.5 1.6-7.5 4.8-9.4 9.7L31.2 51H23L14 13Z" fill="#ffffff" fill-opacity="0.14" />
+  <path d="M17 16h7.7l7.1 22.3L39 16h7.7L35.8 48h-7.2L17 16Z" fill="#ffffff" />
+  <path d="M41.8 16H49v25.3h-5.8L41.8 48H34V33.7l7.8-17.7Z" fill="#ffffff" />
+  <path d="M14 14h36c-3.2 1.2-5.7 3.2-7.5 6H19.2L14 14Z" fill="url(#shine)" />
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -1,29 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#f8fffe" />
       <stop offset="100%" stop-color="#dff8f4" />
     </linearGradient>
-    <linearGradient id="brand" x1="0%" x2="100%" y1="0%" y2="100%">
-      <stop offset="0%" stop-color="#4ccfc5" />
-      <stop offset="100%" stop-color="#8be7da" />
+    <linearGradient id="brand" x1="10%" y1="8%" x2="90%" y2="92%">
+      <stop offset="0%" stop-color="#7de7dc" />
+      <stop offset="100%" stop-color="#1fabb3" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
-  <circle cx="1040" cy="120" r="170" fill="#c8f5ef" opacity="0.7" />
-  <circle cx="180" cy="120" r="120" fill="#e8fbf8" />
-  <rect x="86" y="88" width="96" height="96" rx="28" fill="url(#brand)" />
-  <path
-    d="M112 112h11l11.2 33.5 11.2-33.5h10.7L139.5 160h-10L112 112Zm41.9 0H165v37.8h-16.2V160h-10.9V112Z"
-    fill="#ffffff"
-  />
-  <text x="86" y="272" fill="#16333a" font-family="Sora, Arial, sans-serif" font-size="74" font-weight="700">
+  <circle cx="1038" cy="114" r="176" fill="#c8f5ef" opacity="0.72" />
+  <circle cx="148" cy="108" r="132" fill="#ebfcf9" />
+  <circle cx="1126" cy="534" r="94" fill="#d4f8f2" opacity="0.84" />
+  <rect x="86" y="84" width="104" height="104" rx="30" fill="url(#brand)" />
+  <path d="M107 102h62c-7.9 2.7-13.6 8-17.2 15.9L134.4 170h-14.6L107 102Z" fill="#ffffff" fill-opacity="0.14" />
+  <path d="M116 112h12.5l11.6 36.3 11.7-36.3h12.5L146.9 164h-11.8L116 112Z" fill="#ffffff" />
+  <path d="M156.8 112h11.8v41.2h-9.4l-2.4 10.8H144V140.7l12.8-28.7Z" fill="#ffffff" />
+  <text x="86" y="276" fill="#16333a" font-family="Sora, Arial, sans-serif" font-size="76" font-weight="700">
     Vindem Labs
   </text>
-  <text x="86" y="350" fill="#53717a" font-family="Sora, Arial, sans-serif" font-size="30">
-    Consumer apps, enterprise software, digital media, and intelligent systems.
+  <text x="86" y="352" fill="#53717a" font-family="Sora, Arial, sans-serif" font-size="31">
+    Consumer applications, enterprise software, publisher platforms, and connected systems.
   </text>
-  <text x="86" y="440" fill="#1d9ea7" font-family="Sora, Arial, sans-serif" font-size="22" font-weight="700">
+  <text x="86" y="442" fill="#1d9ea7" font-family="Sora, Arial, sans-serif" font-size="22" font-weight="700">
     PropTech  •  AI Education  •  Property Operations  •  IoT Integrations
   </text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
       }
 
       .brand-mark img {
+        display: block;
         width: 100%;
         height: 100%;
       }

--- a/index.html
+++ b/index.html
@@ -105,27 +105,14 @@
         width: 2.7rem;
         height: 2.7rem;
         border-radius: 0.95rem;
-        background: linear-gradient(145deg, var(--brand), #7be4dc);
-        box-shadow:
-          inset 0 1px 0 rgba(255, 255, 255, 0.45),
-          0 8px 22px rgba(29, 158, 167, 0.22);
-        position: relative;
+        box-shadow: 0 8px 22px rgba(29, 158, 167, 0.18);
         overflow: hidden;
+        flex: 0 0 auto;
       }
 
-      .brand-mark::before,
-      .brand-mark::after {
-        content: "";
-        position: absolute;
-        inset: 18%;
-        border-radius: 999px 999px 999px 0;
-        border: 2px solid rgba(255, 255, 255, 0.86);
-        transform: rotate(45deg);
-      }
-
-      .brand-mark::after {
-        inset: 35%;
-        opacity: 0.72;
+      .brand-mark img {
+        width: 100%;
+        height: 100%;
       }
 
       .brand-copy small {
@@ -672,7 +659,9 @@
     <header class="site-header">
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
-          <span class="brand-mark" aria-hidden="true"></span>
+          <span class="brand-mark" aria-hidden="true">
+            <img src="assets/favicon.svg" alt="" />
+          </span>
           <span class="brand-copy">
             Vindem Labs
             <small>Web, mobile, software, and digital platforms</small>


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Current updates:
- refresh the Vindem Labs brand mark so the site header, favicon, and social preview all use the same visual identity
- add the local `ux-only` automation scaffolding so this repo follows the same rolling UX workflow pattern as the notifications repo