### PR TITLE
Rolling UX updates

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,17 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
-    <linearGradient id="bg" x1="8%" y1="6%" x2="92%" y2="94%">
-      <stop offset="0%" stop-color="#7de7dc" />
-      <stop offset="100%" stop-color="#1fabb3" />
+    <linearGradient id="mark-bg" x1="10%" y1="8%" x2="90%" y2="92%">
+      <stop offset="0%" stop-color="#e9fffb" />
+      <stop offset="100%" stop-color="#b7eee8" />
     </linearGradient>
-    <linearGradient id="shine" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.78" />
-      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    <linearGradient id="stroke" x1="14%" y1="12%" x2="86%" y2="88%">
+      <stop offset="0%" stop-color="#0aa7b1" />
+      <stop offset="100%" stop-color="#16333a" />
     </linearGradient>
   </defs>
-  <rect width="64" height="64" rx="18" fill="url(#bg)" />
-  <path d="M14 13h36c-4.5 1.6-7.5 4.8-9.4 9.7L31.2 51H23L14 13Z" fill="#ffffff" fill-opacity="0.14" />
-  <path d="M17 16h7.7l7.1 22.3L39 16h7.7L35.8 48h-7.2L17 16Z" fill="#ffffff" />
-  <path d="M41.8 16H49v25.3h-5.8L41.8 48H34V33.7l7.8-17.7Z" fill="#ffffff" />
-  <path d="M14 14h36c-3.2 1.2-5.7 3.2-7.5 6H19.2L14 14Z" fill="url(#shine)" />
+  <rect x="3" y="3" width="58" height="58" rx="16" fill="url(#mark-bg)" />
+  <rect x="3.75" y="3.75" width="56.5" height="56.5" rx="15.25" fill="none" stroke="#ffffff" stroke-width="1.5" />
+  <path d="M15 17L28.4 47L38.8 17" fill="none" stroke="url(#stroke)" stroke-width="6.2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M39 17V47H51" fill="none" stroke="url(#stroke)" stroke-width="6.2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M31.5 34.8H43.5" fill="none" stroke="#f2b36d" stroke-width="4.4" stroke-linecap="round" />
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -1,29 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f8fffe" />
-      <stop offset="100%" stop-color="#dff8f4" />
+      <stop offset="0%" stop-color="#fbfefe" />
+      <stop offset="100%" stop-color="#dff7f4" />
     </linearGradient>
-    <linearGradient id="brand" x1="10%" y1="8%" x2="90%" y2="92%">
-      <stop offset="0%" stop-color="#7de7dc" />
-      <stop offset="100%" stop-color="#1fabb3" />
+    <linearGradient id="tile" x1="10%" y1="8%" x2="90%" y2="92%">
+      <stop offset="0%" stop-color="#e9fffb" />
+      <stop offset="100%" stop-color="#b7eee8" />
+    </linearGradient>
+    <linearGradient id="stroke" x1="14%" y1="12%" x2="86%" y2="88%">
+      <stop offset="0%" stop-color="#0aa7b1" />
+      <stop offset="100%" stop-color="#16333a" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
-  <circle cx="1038" cy="114" r="176" fill="#c8f5ef" opacity="0.72" />
-  <circle cx="148" cy="108" r="132" fill="#ebfcf9" />
-  <circle cx="1126" cy="534" r="94" fill="#d4f8f2" opacity="0.84" />
-  <rect x="86" y="84" width="104" height="104" rx="30" fill="url(#brand)" />
-  <path d="M107 102h62c-7.9 2.7-13.6 8-17.2 15.9L134.4 170h-14.6L107 102Z" fill="#ffffff" fill-opacity="0.14" />
-  <path d="M116 112h12.5l11.6 36.3 11.7-36.3h12.5L146.9 164h-11.8L116 112Z" fill="#ffffff" />
-  <path d="M156.8 112h11.8v41.2h-9.4l-2.4 10.8H144V140.7l12.8-28.7Z" fill="#ffffff" />
-  <text x="86" y="276" fill="#16333a" font-family="Sora, Arial, sans-serif" font-size="76" font-weight="700">
-    Vindem Labs
-  </text>
-  <text x="86" y="352" fill="#53717a" font-family="Sora, Arial, sans-serif" font-size="31">
-    Consumer applications, enterprise software, publisher platforms, and connected systems.
-  </text>
-  <text x="86" y="442" fill="#1d9ea7" font-family="Sora, Arial, sans-serif" font-size="22" font-weight="700">
-    PropTech  •  AI Education  •  Property Operations  •  IoT Integrations
-  </text>
+  <path d="M742 0H1200V630H882C792 506 754 367 768 214C775 137 767 66 742 0Z" fill="#caefea" opacity="0.5" />
+  <path d="M0 512C152 485 292 496 420 545C524 585 626 586 726 550V630H0Z" fill="#f2b36d" opacity="0.18" />
+  <rect x="86" y="82" width="116" height="116" rx="30" fill="url(#tile)" />
+  <rect x="87" y="83" width="114" height="114" rx="29" fill="none" stroke="#ffffff" stroke-width="2" />
+  <path d="M111 110L135.4 168L154.2 110" fill="none" stroke="url(#stroke)" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M154.5 110V168H178" fill="none" stroke="url(#stroke)" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M141 145H165" fill="none" stroke="#f2b36d" stroke-width="8" stroke-linecap="round" />
+  <text x="86" y="294" fill="#172f35" font-family="Sora, Arial, sans-serif" font-size="78" font-weight="700">Vindem Labs</text>
+  <text x="86" y="366" fill="#546b71" font-family="Sora, Arial, sans-serif" font-size="31">Digital products, business software, publishing platforms, and connected systems.</text>
+  <text x="86" y="456" fill="#087f8c" font-family="Sora, Arial, sans-serif" font-size="23" font-weight="700">PropTech | AI Education | Property Operations | IoT Integrations</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -20,19 +20,20 @@
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <style>
       :root {
-        --bg: #effaf8;
-        --bg-deep: #dff8f4;
+        --bg: #f4fbfa;
+        --bg-deep: #dff7f4;
         --panel: rgba(255, 255, 255, 0.82);
         --panel-strong: rgba(255, 255, 255, 0.94);
-        --text: #16333a;
-        --muted: #53717a;
+        --text: #172f35;
+        --muted: #546b71;
         --line: rgba(22, 51, 58, 0.1);
-        --brand: #4ccfc5;
-        --brand-deep: #1d9ea7;
-        --brand-soft: #bff4ef;
-        --accent: #8be7da;
-        --shadow: 0 24px 64px rgba(24, 71, 79, 0.12);
-        --radius: 26px;
+        --brand: #18bfc0;
+        --brand-deep: #087f8c;
+        --brand-soft: #caefea;
+        --accent: #f2b36d;
+        --ink: #24404a;
+        --shadow: 0 18px 42px rgba(24, 71, 79, 0.1);
+        --radius: 22px;
         --max: 1180px;
       }
 
@@ -49,8 +50,8 @@
         font-family: "Sora", "Avenir Next", "Segoe UI", sans-serif;
         color: var(--text);
         background:
-          radial-gradient(circle at top left, rgba(139, 231, 218, 0.42), transparent 28%),
-          radial-gradient(circle at 92% 12%, rgba(76, 207, 197, 0.28), transparent 22%),
+          linear-gradient(120deg, rgba(242, 179, 109, 0.09), transparent 34%),
+          linear-gradient(180deg, rgba(24, 191, 192, 0.1), transparent 26%),
           linear-gradient(180deg, #fbfefe 0%, var(--bg) 48%, var(--bg-deep) 100%);
       }
 
@@ -98,7 +99,7 @@
         align-items: center;
         gap: 0.9rem;
         font-weight: 800;
-        letter-spacing: -0.04em;
+        letter-spacing: 0;
       }
 
       .brand-mark {
@@ -148,7 +149,7 @@
         align-items: center;
         justify-content: center;
         gap: 0.6rem;
-        border-radius: 999px;
+        border-radius: 0.8rem;
         padding: 0.92rem 1.28rem;
         border: 1px solid transparent;
         font-weight: 700;
@@ -172,7 +173,7 @@
       }
 
       main section {
-        padding: 4.5rem 0;
+        padding: 4.25rem 0;
       }
 
       .hero {
@@ -181,9 +182,9 @@
 
       .hero-grid {
         display: grid;
-        grid-template-columns: 1.16fr 0.94fr;
+        grid-template-columns: minmax(0, 1.08fr) minmax(340px, 0.92fr);
         gap: 2rem;
-        align-items: stretch;
+        align-items: center;
       }
 
       .hero-copy {
@@ -196,7 +197,7 @@
         gap: 0.5rem;
         margin-bottom: 1.2rem;
         padding: 0.5rem 0.85rem;
-        border-radius: 999px;
+        border-radius: 0.8rem;
         font-size: 0.82rem;
         font-weight: 800;
         letter-spacing: 0.08em;
@@ -213,10 +214,10 @@
       }
 
       h1 {
-        font-size: clamp(2.9rem, 7vw, 5.8rem);
-        line-height: 0.96;
-        letter-spacing: -0.06em;
-        max-width: 12ch;
+        font-size: 4.8rem;
+        line-height: 1;
+        letter-spacing: 0;
+        max-width: 13ch;
       }
 
       .hero-copy p {
@@ -264,7 +265,7 @@
       .metric-card strong {
         display: block;
         font-size: 1.7rem;
-        letter-spacing: -0.05em;
+        letter-spacing: 0;
       }
 
       .metric-card span {
@@ -274,29 +275,24 @@
 
       .glass-card {
         border-radius: var(--radius);
-        padding: 1.5rem;
+        padding: 1.55rem;
         position: relative;
         overflow: hidden;
       }
 
       .glass-card::before {
-        content: "";
-        position: absolute;
-        inset: auto -10% -22% auto;
-        width: 240px;
-        height: 240px;
-        border-radius: 50%;
-        background: radial-gradient(circle, rgba(76, 207, 197, 0.24), transparent 66%);
+        content: none;
       }
 
       .hero-board {
         display: grid;
-        gap: 1rem;
+        gap: 1.1rem;
+        align-self: stretch;
       }
 
       .hero-board h2 {
-        font-size: 1.5rem;
-        letter-spacing: -0.04em;
+        font-size: 1.45rem;
+        letter-spacing: 0;
         margin-bottom: 0.55rem;
       }
 
@@ -312,6 +308,7 @@
         line-height: 1.65;
       }
 
+      .delivery-list,
       .pill-list,
       .stat-list {
         display: flex;
@@ -319,10 +316,45 @@
         gap: 0.7rem;
       }
 
+      .delivery-list {
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .delivery-item {
+        display: grid;
+        grid-template-columns: 3rem minmax(0, 1fr);
+        gap: 0.85rem;
+        align-items: start;
+        padding: 0.9rem 0;
+        border-top: 1px solid rgba(22, 51, 58, 0.08);
+      }
+
+      .delivery-item:first-child {
+        border-top: 0;
+        padding-top: 0;
+      }
+
+      .delivery-item .delivery-code {
+        color: var(--brand-deep);
+        font-size: 0.78rem;
+        font-weight: 800;
+      }
+
+      .delivery-item strong {
+        display: block;
+        margin-bottom: 0.2rem;
+      }
+
+      .delivery-note {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+      }
+
       .pill-list span,
       .stat-list span {
         padding: 0.6rem 0.85rem;
-        border-radius: 999px;
+        border-radius: 0.7rem;
         font-size: 0.88rem;
         background: rgba(22, 51, 58, 0.05);
       }
@@ -336,9 +368,9 @@
       }
 
       .section-head h2 {
-        font-size: clamp(2rem, 5vw, 3.45rem);
-        line-height: 1.02;
-        letter-spacing: -0.05em;
+        font-size: 3rem;
+        line-height: 1.08;
+        letter-spacing: 0;
       }
 
       .section-kicker {
@@ -415,12 +447,12 @@
 
       .stream-header h3 {
         font-size: 1.8rem;
-        letter-spacing: -0.04em;
+        letter-spacing: 0;
       }
 
       .stream-badge {
         padding: 0.45rem 0.7rem;
-        border-radius: 999px;
+        border-radius: 0.7rem;
         background: rgba(76, 207, 197, 0.13);
         color: var(--brand-deep);
         white-space: nowrap;
@@ -449,7 +481,7 @@
       .timeline-card,
       .quote-card {
         padding: 1rem;
-        border-radius: 1.1rem;
+        border-radius: 0.8rem;
         background: rgba(22, 51, 58, 0.04);
         border: 1px solid rgba(22, 51, 58, 0.06);
       }
@@ -506,14 +538,7 @@
       }
 
       .timeline-card::after {
-        content: "";
-        position: absolute;
-        top: 1rem;
-        right: 1rem;
-        width: 42px;
-        height: 42px;
-        border-radius: 50%;
-        background: rgba(76, 207, 197, 0.15);
+        content: none;
       }
 
       .contact-layout {
@@ -628,6 +653,14 @@
         .stream-panel {
           min-height: auto;
         }
+
+        h1 {
+          font-size: 3.7rem;
+        }
+
+        .section-head h2 {
+          font-size: 2.45rem;
+        }
       }
 
       @media (max-width: 640px) {
@@ -640,7 +673,17 @@
         }
 
         h1 {
-          max-width: 9.5ch;
+          font-size: 2.75rem;
+          max-width: 11ch;
+        }
+
+        .section-head h2 {
+          font-size: 2rem;
+        }
+
+        .delivery-item {
+          grid-template-columns: 1fr;
+          gap: 0.25rem;
         }
 
         .glass-card,
@@ -717,28 +760,44 @@
             <div>
               <h2>What Vindem Labs delivers</h2>
               <p>
-                Vindem Labs brings together product thinking, design, software delivery, and
-                digital growth capability so clients can work with one team across multiple parts
-                of the same ecosystem.
+                Vindem Labs brings product thinking, design, software delivery, and growth-focused
+                web work into one clear engagement.
               </p>
             </div>
 
-            <div class="pill-list" aria-label="Core themes">
-              <span>Product design</span>
-              <span>Web platforms</span>
-              <span>Mobile apps</span>
-              <span>Business software</span>
-              <span>IoT integrations</span>
-              <span>Content ecosystems</span>
+            <div class="delivery-list" aria-label="Core delivery areas">
+              <div class="delivery-item">
+                <span class="delivery-code">01</span>
+                <div>
+                  <strong>Applications</strong>
+                  <p>Customer-facing web and mobile products with clean journeys and room to grow.</p>
+                </div>
+              </div>
+              <div class="delivery-item">
+                <span class="delivery-code">02</span>
+                <div>
+                  <strong>Business software</strong>
+                  <p>Internal tools, dashboards, and platforms for operations that need clarity.</p>
+                </div>
+              </div>
+              <div class="delivery-item">
+                <span class="delivery-code">03</span>
+                <div>
+                  <strong>Publishing platforms</strong>
+                  <p>Content-led websites designed for search, authority, and monetization.</p>
+                </div>
+              </div>
+              <div class="delivery-item">
+                <span class="delivery-code">04</span>
+                <div>
+                  <strong>Connected systems</strong>
+                  <p>Interfaces and integrations for IoT, property operations, and data visibility.</p>
+                </div>
+              </div>
             </div>
 
-            <div class="sub-item">
-              <strong>Built around real business needs</strong>
-              <p>
-                Whether the need is a client-facing application, an enterprise platform, a content
-                website, or an integrated device experience, the work is shaped around outcomes,
-                usability, and long-term maintainability.
-              </p>
+            <div class="delivery-note">
+              <p>Built around outcomes, usability, and long-term maintainability.</p>
             </div>
           </aside>
         </div>


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Current update:
- move active project work into `/Users/mrv/workspace/v-labs-core.github.io`
- refresh the Vindem Labs mark and social preview asset
- clean up the homepage layout, especially the "What Vindem Labs delivers" section alignment and typography