### PR TITLE
Rolling UX updates

### DIFF
--- a/.local-automation/ux_polish_prompt.txt
+++ b/.local-automation/ux_polish_prompt.txt
@@ -5,4 +5,5 @@ Rules:
 - Focus on visible UX, layout, visual clarity, copy polish, responsiveness, accessibility, or branding.
 - Avoid backend work.
 - Keep the change small enough for a rolling PR.
+- Do not change this protected homepage line or its simple left-accent treatment: "Built around outcomes, usability, and long-term maintainability."
 - After the change, commit it to `ux-only` with a concise message and push it.

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,19 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
-    <linearGradient id="tile" x1="7%" y1="6%" x2="93%" y2="94%">
-      <stop offset="0%" stop-color="#fff4df" />
-      <stop offset="48%" stop-color="#ccefe4" />
-      <stop offset="100%" stop-color="#68d8d1" />
+    <linearGradient id="tile" x1="8%" y1="4%" x2="92%" y2="96%">
+      <stop offset="0%" stop-color="#fff2dc" />
+      <stop offset="46%" stop-color="#dff8ef" />
+      <stop offset="100%" stop-color="#62d4d0" />
     </linearGradient>
-    <linearGradient id="mark" x1="18%" y1="12%" x2="82%" y2="88%">
-      <stop offset="0%" stop-color="#0aa6a6" />
-      <stop offset="100%" stop-color="#15313a" />
+    <linearGradient id="ribbon" x1="14%" y1="8%" x2="86%" y2="92%">
+      <stop offset="0%" stop-color="#00a7b3" />
+      <stop offset="100%" stop-color="#07545d" />
     </linearGradient>
+    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
+      <feDropShadow dx="0" dy="3" stdDeviation="2.4" flood-color="#07545d" flood-opacity="0.22" />
+    </filter>
   </defs>
-  <rect x="3" y="3" width="58" height="58" rx="17" fill="url(#tile)" />
-  <path d="M13 18C20 10 34 8 46 15C55 20 59 30 55 42C51 54 39 59 27 55C15 51 8 40 10 29C11 24 11 21 13 18Z" fill="#ffffff" opacity="0.58" />
-  <path d="M15 18H23L31.2 43.5L40.2 18H48L35.7 50H26.5L15 18Z" fill="url(#mark)" />
-  <path d="M41.2 18H49V42.7H55V50H41.2V18Z" fill="#15313a" opacity="0.92" />
-  <path d="M21.4 32.5C28.5 27.2 36.8 27.2 46.4 32.6" fill="none" stroke="#fff4df" stroke-width="4.6" stroke-linecap="round" />
-  <circle cx="47.8" cy="22.2" r="3.4" fill="#ffb86b" />
+  <rect x="4" y="4" width="56" height="56" rx="18" fill="url(#tile)" />
+  <path d="M11 45C19 50 29 52 39 49C49 46 55 37 53 27C52 19 46 12 38 10C48 14 53 23 50 33C46 47 29 54 11 45Z" fill="#ffffff" opacity="0.62" />
+  <g filter="url(#lift)">
+    <path d="M13.6 17H22.2L31.9 43.7L41.6 17H50.4L36.8 49H27.4L13.6 17Z" fill="url(#ribbon)" />
+    <path d="M41.7 17H50.4V42.1H56V49H41.7V17Z" fill="#133138" />
+  </g>
+  <path d="M22.2 31.7C28.9 27.2 37.2 27.2 44.2 31.7" fill="none" stroke="#fff2dc" stroke-width="4.2" stroke-linecap="round" />
+  <circle cx="47.5" cy="20.2" r="3.4" fill="#f4976c" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -9,10 +9,10 @@
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <linearGradient id="sunset" x1="20%" y1="0%" x2="82%" y2="100%">
-      <stop offset="0%" stop-color="#ffd28a" />
-      <stop offset="48%" stop-color="#f4976c" />
-      <stop offset="100%" stop-color="#df6f5e" />
+    <linearGradient id="sunset" x1="17" y1="50" x2="51" y2="55" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffd26f" />
+      <stop offset="42%" stop-color="#ff9f4a" />
+      <stop offset="100%" stop-color="#d95f52" />
     </linearGradient>
     <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
       <feDropShadow dx="0" dy="3" stdDeviation="2.3" flood-color="#07545d" flood-opacity="0.2" />
@@ -24,5 +24,5 @@
     <path d="M14.2 17L28.4 47.5L40.8 17" stroke-width="6.6" />
     <path d="M43.8 17V44.4C43.8 47 45.8 49 48.4 49H54" stroke-width="6.6" />
   </g>
-  <path d="M21.8 52.2H47.2" fill="none" stroke="url(#sunset)" stroke-width="3.7" stroke-linecap="round" />
+  <rect x="17" y="50" width="34" height="5.8" rx="2.9" fill="url(#sunset)" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -9,6 +9,11 @@
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
+    <linearGradient id="sunset" x1="20%" y1="0%" x2="82%" y2="100%">
+      <stop offset="0%" stop-color="#ffd28a" />
+      <stop offset="48%" stop-color="#f4976c" />
+      <stop offset="100%" stop-color="#df6f5e" />
+    </linearGradient>
     <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
       <feDropShadow dx="0" dy="3" stdDeviation="2.3" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
@@ -19,6 +24,5 @@
     <path d="M14.2 17L28.4 47.5L40.8 17" stroke-width="6.6" />
     <path d="M43.8 17V44.4C43.8 47 45.8 49 48.4 49H54" stroke-width="6.6" />
   </g>
-  <path d="M21.8 52.2H47.2" fill="none" stroke="#f4976c" stroke-width="3.5" stroke-linecap="round" opacity="0.95" />
-  <path d="M23 51.1H46" fill="none" stroke="#fff6e8" stroke-width="1.1" stroke-linecap="round" opacity="0.6" />
+  <path d="M21.8 52.2H47.2" fill="none" stroke="url(#sunset)" stroke-width="3.7" stroke-linecap="round" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -2,23 +2,23 @@
   <defs>
     <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
       <stop offset="0%" stop-color="#fff6e8" />
-      <stop offset="52%" stop-color="#d7f8f0" />
+      <stop offset="55%" stop-color="#d7f8f0" />
       <stop offset="100%" stop-color="#6ddbd5" />
     </linearGradient>
-    <linearGradient id="ink" x1="20%" y1="12%" x2="82%" y2="88%">
+    <linearGradient id="ink" x1="16%" y1="12%" x2="84%" y2="88%">
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <filter id="soft-shadow" x="-18%" y="-18%" width="136%" height="136%">
-      <feDropShadow dx="0" dy="3" stdDeviation="2.2" flood-color="#07545d" flood-opacity="0.2" />
+    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
+      <feDropShadow dx="0" dy="3" stdDeviation="2.3" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
   </defs>
   <rect x="3" y="3" width="58" height="58" rx="18" fill="url(#tile)" />
-  <path d="M9 18C17 10 31 8 43 13C54 18 59 29 56 41C53 52 44 58 31 57C18 56 9 48 8 36C7 28 5 22 9 18Z" fill="#ffffff" opacity="0.58" />
-  <g filter="url(#soft-shadow)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M14.5 17L28.7 48L42.8 17" stroke-width="7.2" />
-    <path d="M45.5 17V44.2C45.5 47 47.5 49 50.3 49H55" stroke-width="7.2" />
+  <path d="M10 18C20 9 35 9 47 17C55 22 59 31 56 42C53 53 44 58 32 57C20 56 10 49 8 37C7 29 6 23 10 18Z" fill="#ffffff" opacity="0.65" />
+  <g filter="url(#lift)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M14.2 17L28.4 47.5L40.8 17" stroke-width="6.6" />
+    <path d="M43.8 17V44.4C43.8 47 45.8 49 48.4 49H54" stroke-width="6.6" />
   </g>
-  <path d="M20 18.2L29 38.2L37.9 18.2" fill="none" stroke="#eafffb" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" opacity="0.82" />
-  <path d="M50.8 18.2V42.3C50.8 43.1 51.2 43.5 52 43.5H55" fill="none" stroke="#eafffb" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" opacity="0.7" />
+  <path d="M24.2 35.2C30.6 29.6 38.1 29.4 46.6 34.5" fill="none" stroke="#f4976c" stroke-width="3.2" stroke-linecap="round" opacity="0.95" />
+  <path d="M24.2 35.2C30.6 29.6 38.1 29.4 46.6 34.5" fill="none" stroke="#fff6e8" stroke-width="1.15" stroke-linecap="round" opacity="0.7" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -19,6 +19,6 @@
     <path d="M14.2 17L28.4 47.5L40.8 17" stroke-width="6.6" />
     <path d="M43.8 17V44.4C43.8 47 45.8 49 48.4 49H54" stroke-width="6.6" />
   </g>
-  <path d="M24.2 35.2C30.6 29.6 38.1 29.4 46.6 34.5" fill="none" stroke="#f4976c" stroke-width="3.2" stroke-linecap="round" opacity="0.95" />
-  <path d="M24.2 35.2C30.6 29.6 38.1 29.4 46.6 34.5" fill="none" stroke="#fff6e8" stroke-width="1.15" stroke-linecap="round" opacity="0.7" />
+  <path d="M21.8 52.2H47.2" fill="none" stroke="#f4976c" stroke-width="3.5" stroke-linecap="round" opacity="0.95" />
+  <path d="M23 51.1H46" fill="none" stroke="#fff6e8" stroke-width="1.1" stroke-linecap="round" opacity="0.6" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,17 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
-    <linearGradient id="mark-bg" x1="10%" y1="8%" x2="90%" y2="92%">
-      <stop offset="0%" stop-color="#e9fffb" />
-      <stop offset="100%" stop-color="#b7eee8" />
+    <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
+      <stop offset="0%" stop-color="#f4fffd" />
+      <stop offset="58%" stop-color="#bff7ef" />
+      <stop offset="100%" stop-color="#74eadf" />
     </linearGradient>
-    <linearGradient id="stroke" x1="14%" y1="12%" x2="86%" y2="88%">
-      <stop offset="0%" stop-color="#0aa7b1" />
-      <stop offset="100%" stop-color="#16333a" />
+    <linearGradient id="ink" x1="18%" y1="12%" x2="82%" y2="88%">
+      <stop offset="0%" stop-color="#00d6c9" />
+      <stop offset="100%" stop-color="#0d3440" />
+    </linearGradient>
+    <linearGradient id="glow" x1="20%" y1="18%" x2="80%" y2="82%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
     </linearGradient>
   </defs>
-  <rect x="3" y="3" width="58" height="58" rx="16" fill="url(#mark-bg)" />
-  <rect x="3.75" y="3.75" width="56.5" height="56.5" rx="15.25" fill="none" stroke="#ffffff" stroke-width="1.5" />
-  <path d="M15 17L28.4 47L38.8 17" fill="none" stroke="url(#stroke)" stroke-width="6.2" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M39 17V47H51" fill="none" stroke="url(#stroke)" stroke-width="6.2" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M31.5 34.8H43.5" fill="none" stroke="#f2b36d" stroke-width="4.4" stroke-linecap="round" />
+  <rect x="3" y="3" width="58" height="58" rx="18" fill="url(#tile)" />
+  <path d="M10 18C20 9 35 9 47 17C55 22 59 31 56 42C53 53 44 58 32 57C20 56 10 49 8 37C7 29 6 23 10 18Z" fill="url(#glow)" opacity="0.7" />
+  <path d="M14 17L27.8 47L39.5 17" fill="none" stroke="url(#ink)" stroke-width="6.4" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M40 17V45.5C40 47.4 41.6 49 43.5 49H52" fill="none" stroke="url(#ink)" stroke-width="6.4" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M24 35C30 29 37 28.5 45 33.5" fill="none" stroke="#e8fffb" stroke-width="4" stroke-linecap="round" opacity="0.95" />
+  <path d="M24 35C30 29 37 28.5 45 33.5" fill="none" stroke="#00d6c9" stroke-width="2" stroke-linecap="round" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,23 +1,19 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
-    <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
-      <stop offset="0%" stop-color="#f4fffd" />
-      <stop offset="58%" stop-color="#bff7ef" />
-      <stop offset="100%" stop-color="#74eadf" />
+    <linearGradient id="tile" x1="7%" y1="6%" x2="93%" y2="94%">
+      <stop offset="0%" stop-color="#fff4df" />
+      <stop offset="48%" stop-color="#ccefe4" />
+      <stop offset="100%" stop-color="#68d8d1" />
     </linearGradient>
-    <linearGradient id="ink" x1="18%" y1="12%" x2="82%" y2="88%">
-      <stop offset="0%" stop-color="#00d6c9" />
-      <stop offset="100%" stop-color="#0d3440" />
-    </linearGradient>
-    <linearGradient id="glow" x1="20%" y1="18%" x2="80%" y2="82%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
-      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    <linearGradient id="mark" x1="18%" y1="12%" x2="82%" y2="88%">
+      <stop offset="0%" stop-color="#0aa6a6" />
+      <stop offset="100%" stop-color="#15313a" />
     </linearGradient>
   </defs>
-  <rect x="3" y="3" width="58" height="58" rx="18" fill="url(#tile)" />
-  <path d="M10 18C20 9 35 9 47 17C55 22 59 31 56 42C53 53 44 58 32 57C20 56 10 49 8 37C7 29 6 23 10 18Z" fill="url(#glow)" opacity="0.7" />
-  <path d="M14 17L27.8 47L39.5 17" fill="none" stroke="url(#ink)" stroke-width="6.4" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M40 17V45.5C40 47.4 41.6 49 43.5 49H52" fill="none" stroke="url(#ink)" stroke-width="6.4" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M24 35C30 29 37 28.5 45 33.5" fill="none" stroke="#e8fffb" stroke-width="4" stroke-linecap="round" opacity="0.95" />
-  <path d="M24 35C30 29 37 28.5 45 33.5" fill="none" stroke="#00d6c9" stroke-width="2" stroke-linecap="round" />
+  <rect x="3" y="3" width="58" height="58" rx="17" fill="url(#tile)" />
+  <path d="M13 18C20 10 34 8 46 15C55 20 59 30 55 42C51 54 39 59 27 55C15 51 8 40 10 29C11 24 11 21 13 18Z" fill="#ffffff" opacity="0.58" />
+  <path d="M15 18H23L31.2 43.5L40.2 18H48L35.7 50H26.5L15 18Z" fill="url(#mark)" />
+  <path d="M41.2 18H49V42.7H55V50H41.2V18Z" fill="#15313a" opacity="0.92" />
+  <path d="M21.4 32.5C28.5 27.2 36.8 27.2 46.4 32.6" fill="none" stroke="#fff4df" stroke-width="4.6" stroke-linecap="round" />
+  <circle cx="47.8" cy="22.2" r="3.4" fill="#ffb86b" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,24 +1,24 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
-    <linearGradient id="tile" x1="8%" y1="4%" x2="92%" y2="96%">
-      <stop offset="0%" stop-color="#fff2dc" />
-      <stop offset="46%" stop-color="#dff8ef" />
-      <stop offset="100%" stop-color="#62d4d0" />
+    <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
+      <stop offset="0%" stop-color="#fff6e8" />
+      <stop offset="52%" stop-color="#d7f8f0" />
+      <stop offset="100%" stop-color="#6ddbd5" />
     </linearGradient>
-    <linearGradient id="ribbon" x1="14%" y1="8%" x2="86%" y2="92%">
+    <linearGradient id="ink" x1="20%" y1="12%" x2="82%" y2="88%">
       <stop offset="0%" stop-color="#00a7b3" />
-      <stop offset="100%" stop-color="#07545d" />
+      <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
-      <feDropShadow dx="0" dy="3" stdDeviation="2.4" flood-color="#07545d" flood-opacity="0.22" />
+    <filter id="soft-shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="3" stdDeviation="2.2" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
   </defs>
-  <rect x="4" y="4" width="56" height="56" rx="18" fill="url(#tile)" />
-  <path d="M11 45C19 50 29 52 39 49C49 46 55 37 53 27C52 19 46 12 38 10C48 14 53 23 50 33C46 47 29 54 11 45Z" fill="#ffffff" opacity="0.62" />
-  <g filter="url(#lift)">
-    <path d="M13.6 17H22.2L31.9 43.7L41.6 17H50.4L36.8 49H27.4L13.6 17Z" fill="url(#ribbon)" />
-    <path d="M41.7 17H50.4V42.1H56V49H41.7V17Z" fill="#133138" />
+  <rect x="3" y="3" width="58" height="58" rx="18" fill="url(#tile)" />
+  <path d="M9 18C17 10 31 8 43 13C54 18 59 29 56 41C53 52 44 58 31 57C18 56 9 48 8 36C7 28 5 22 9 18Z" fill="#ffffff" opacity="0.58" />
+  <g filter="url(#soft-shadow)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M14.5 17L28.7 48L42.8 17" stroke-width="7.2" />
+    <path d="M45.5 17V44.2C45.5 47 47.5 49 50.3 49H55" stroke-width="7.2" />
   </g>
-  <path d="M22.2 31.7C28.9 27.2 37.2 27.2 44.2 31.7" fill="none" stroke="#fff2dc" stroke-width="4.2" stroke-linecap="round" />
-  <circle cx="47.5" cy="20.2" r="3.4" fill="#f4976c" />
+  <path d="M20 18.2L29 38.2L37.9 18.2" fill="none" stroke="#eafffb" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" opacity="0.82" />
+  <path d="M50.8 18.2V42.3C50.8 43.1 51.2 43.5 52 43.5H55" fill="none" stroke="#eafffb" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round" opacity="0.7" />
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -5,17 +5,17 @@
       <stop offset="47%" stop-color="#f5fbf8" />
       <stop offset="100%" stop-color="#d9f4f1" />
     </linearGradient>
-    <linearGradient id="tile" x1="8%" y1="4%" x2="92%" y2="96%">
-      <stop offset="0%" stop-color="#fff2dc" />
-      <stop offset="46%" stop-color="#dff8ef" />
-      <stop offset="100%" stop-color="#62d4d0" />
+    <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
+      <stop offset="0%" stop-color="#fff6e8" />
+      <stop offset="52%" stop-color="#d7f8f0" />
+      <stop offset="100%" stop-color="#6ddbd5" />
     </linearGradient>
-    <linearGradient id="ribbon" x1="14%" y1="8%" x2="86%" y2="92%">
+    <linearGradient id="ink" x1="20%" y1="12%" x2="82%" y2="88%">
       <stop offset="0%" stop-color="#00a7b3" />
-      <stop offset="100%" stop-color="#07545d" />
+      <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
-      <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.22" />
+    <filter id="soft-shadow" x="-18%" y="-18%" width="136%" height="136%">
+      <feDropShadow dx="0" dy="9" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
@@ -25,14 +25,14 @@
   <path d="M762 0H1200V630H888C792 508 754 364 779 212C793 128 805 60 762 0Z" fill="#fff2dc" opacity="0.66" />
   <path d="M970 390C1016 348 1084 348 1138 390" fill="none" stroke="#00a7b3" stroke-width="22" stroke-linecap="round" opacity="0.18" />
 
-  <rect x="86" y="78" width="124" height="124" rx="36" fill="url(#tile)" />
-  <path d="M102 160C120 173 144 178 168 169C190 161 203 140 198 119C195 102 182 88 164 84C188 94 200 116 192 139C179 176 137 184 102 160Z" fill="#ffffff" opacity="0.62" />
-  <g filter="url(#lift)">
-    <path d="M110 109H127L145.5 166L164 109H181L155 176H137L110 109Z" fill="url(#ribbon)" />
-    <path d="M164 109H181V162H193V176H164V109Z" fill="#133138" />
+  <rect x="86" y="78" width="124" height="124" rx="38" fill="url(#tile)" />
+  <path d="M101 111C118 91 153 89 180 106C199 119 206 143 195 165C184 188 156 199 127 189C104 181 90 159 92 135C93 125 94 117 101 111Z" fill="#ffffff" opacity="0.58" />
+  <g filter="url(#soft-shadow)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M111 108L142 176L173 108" stroke-width="14" />
+    <path d="M179 108V162C179 171 185 177 194 177H204" stroke-width="14" />
   </g>
-  <path d="M126 141C141 131 158 131 174 141" fill="none" stroke="#fff2dc" stroke-width="8" stroke-linecap="round" />
-  <circle cx="176" cy="116" r="7" fill="#f4976c" />
+  <path d="M124 111L143 153L162 111" fill="none" stroke="#eafffb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.82" />
+  <path d="M190 111V157C190 160 192 162 195 162H202" fill="none" stroke="#eafffb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.7" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -2,33 +2,39 @@
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#fffefd" />
-      <stop offset="50%" stop-color="#f7fbf6" />
-      <stop offset="100%" stop-color="#d7f1e9" />
+      <stop offset="47%" stop-color="#f5fbf8" />
+      <stop offset="100%" stop-color="#d9f4f1" />
     </linearGradient>
-    <linearGradient id="tile" x1="7%" y1="6%" x2="93%" y2="94%">
-      <stop offset="0%" stop-color="#fff4df" />
-      <stop offset="48%" stop-color="#ccefe4" />
-      <stop offset="100%" stop-color="#68d8d1" />
+    <linearGradient id="tile" x1="8%" y1="4%" x2="92%" y2="96%">
+      <stop offset="0%" stop-color="#fff2dc" />
+      <stop offset="46%" stop-color="#dff8ef" />
+      <stop offset="100%" stop-color="#62d4d0" />
     </linearGradient>
-    <linearGradient id="mark" x1="18%" y1="12%" x2="82%" y2="88%">
-      <stop offset="0%" stop-color="#0aa6a6" />
-      <stop offset="100%" stop-color="#15313a" />
+    <linearGradient id="ribbon" x1="14%" y1="8%" x2="86%" y2="92%">
+      <stop offset="0%" stop-color="#00a7b3" />
+      <stop offset="100%" stop-color="#07545d" />
     </linearGradient>
+    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
+      <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.22" />
+    </filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
-  <circle cx="1012" cy="116" r="184" fill="#bfeade" opacity="0.58" />
-  <circle cx="1060" cy="142" r="82" fill="#ffb86b" opacity="0.18" />
-  <path d="M0 510C142 480 282 493 420 548C532 592 650 586 768 538V630H0Z" fill="#68d8d1" opacity="0.24" />
-  <path d="M770 0H1200V630H890C792 500 758 358 780 204C792 123 806 58 770 0Z" fill="#fff4df" opacity="0.62" />
+  <circle cx="1018" cy="108" r="190" fill="#beece7" opacity="0.68" />
+  <circle cx="1058" cy="145" r="86" fill="#f4976c" opacity="0.2" />
+  <path d="M0 505C144 468 292 493 428 546C546 592 662 588 780 535C900 481 1036 472 1200 518V630H0Z" fill="#62d4d0" opacity="0.24" />
+  <path d="M762 0H1200V630H888C792 508 754 364 779 212C793 128 805 60 762 0Z" fill="#fff2dc" opacity="0.66" />
+  <path d="M970 390C1016 348 1084 348 1138 390" fill="none" stroke="#00a7b3" stroke-width="22" stroke-linecap="round" opacity="0.18" />
 
-  <rect x="86" y="82" width="118" height="118" rx="32" fill="url(#tile)" />
-  <path d="M105 113C119 96 152 93 178 111C197 124 202 153 184 176C166 198 127 199 106 179C88 162 88 132 105 113Z" fill="#ffffff" opacity="0.58" />
-  <path d="M111 112H126L141.5 169L158.5 112H173L150.2 176H133.8L111 112Z" fill="url(#mark)" />
-  <path d="M160 112H175V163H188V176H160V112Z" fill="#15313a" opacity="0.92" />
-  <path d="M122 144C137 132 154 132 174 144" fill="none" stroke="#fff4df" stroke-width="8" stroke-linecap="round" />
-  <circle cx="174" cy="121" r="6.2" fill="#ffb86b" />
+  <rect x="86" y="78" width="124" height="124" rx="36" fill="url(#tile)" />
+  <path d="M102 160C120 173 144 178 168 169C190 161 203 140 198 119C195 102 182 88 164 84C188 94 200 116 192 139C179 176 137 184 102 160Z" fill="#ffffff" opacity="0.62" />
+  <g filter="url(#lift)">
+    <path d="M110 109H127L145.5 166L164 109H181L155 176H137L110 109Z" fill="url(#ribbon)" />
+    <path d="M164 109H181V162H193V176H164V109Z" fill="#133138" />
+  </g>
+  <path d="M126 141C141 131 158 131 174 141" fill="none" stroke="#fff2dc" stroke-width="8" stroke-linecap="round" />
+  <circle cx="176" cy="116" r="7" fill="#f4976c" />
 
-  <text x="86" y="294" fill="#15313a" font-family="Sora, Arial, sans-serif" font-size="78" font-weight="700">Vindem Labs</text>
-  <text x="86" y="366" fill="#557178" font-family="Sora, Arial, sans-serif" font-size="31">Digital products, business software, publishing platforms, and connected systems.</text>
-  <text x="86" y="456" fill="#0b5f68" font-family="Sora, Arial, sans-serif" font-size="23" font-weight="700">PropTech | AI Education | Property Operations | IoT Integrations</text>
+  <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
+  <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>
+  <text x="86" y="464" fill="#07545d" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="23" font-weight="800">PropTech | AI Education | Property Operations | IoT Integrations</text>
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -1,27 +1,38 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fbfefe" />
-      <stop offset="100%" stop-color="#dff7f4" />
+      <stop offset="0%" stop-color="#fbfffe" />
+      <stop offset="52%" stop-color="#effffc" />
+      <stop offset="100%" stop-color="#d9fbf7" />
     </linearGradient>
-    <linearGradient id="tile" x1="10%" y1="8%" x2="90%" y2="92%">
-      <stop offset="0%" stop-color="#e9fffb" />
-      <stop offset="100%" stop-color="#b7eee8" />
+    <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
+      <stop offset="0%" stop-color="#f4fffd" />
+      <stop offset="58%" stop-color="#bff7ef" />
+      <stop offset="100%" stop-color="#74eadf" />
     </linearGradient>
-    <linearGradient id="stroke" x1="14%" y1="12%" x2="86%" y2="88%">
-      <stop offset="0%" stop-color="#0aa7b1" />
-      <stop offset="100%" stop-color="#16333a" />
+    <linearGradient id="ink" x1="18%" y1="12%" x2="82%" y2="88%">
+      <stop offset="0%" stop-color="#00d6c9" />
+      <stop offset="100%" stop-color="#0d3440" />
+    </linearGradient>
+    <linearGradient id="glow" x1="20%" y1="18%" x2="80%" y2="82%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
-  <path d="M742 0H1200V630H882C792 506 754 367 768 214C775 137 767 66 742 0Z" fill="#caefea" opacity="0.5" />
-  <path d="M0 512C152 485 292 496 420 545C524 585 626 586 726 550V630H0Z" fill="#f2b36d" opacity="0.18" />
-  <rect x="86" y="82" width="116" height="116" rx="30" fill="url(#tile)" />
-  <rect x="87" y="83" width="114" height="114" rx="29" fill="none" stroke="#ffffff" stroke-width="2" />
-  <path d="M111 110L135.4 168L154.2 110" fill="none" stroke="url(#stroke)" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M154.5 110V168H178" fill="none" stroke="url(#stroke)" stroke-width="11" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M141 145H165" fill="none" stroke="#f2b36d" stroke-width="8" stroke-linecap="round" />
-  <text x="86" y="294" fill="#172f35" font-family="Sora, Arial, sans-serif" font-size="78" font-weight="700">Vindem Labs</text>
-  <text x="86" y="366" fill="#546b71" font-family="Sora, Arial, sans-serif" font-size="31">Digital products, business software, publishing platforms, and connected systems.</text>
-  <text x="86" y="456" fill="#087f8c" font-family="Sora, Arial, sans-serif" font-size="23" font-weight="700">PropTech | AI Education | Property Operations | IoT Integrations</text>
+  <circle cx="1030" cy="104" r="190" fill="#bff7ef" opacity="0.55" />
+  <circle cx="1032" cy="112" r="108" fill="#00d6c9" opacity="0.14" />
+  <path d="M0 518C156 488 298 499 426 548C536 590 646 588 756 546V630H0Z" fill="#74eadf" opacity="0.28" />
+  <path d="M782 0H1200V630H892C794 500 756 358 775 204C784 127 805 58 782 0Z" fill="#d0faf5" opacity="0.58" />
+
+  <rect x="86" y="82" width="118" height="118" rx="34" fill="url(#tile)" />
+  <path d="M103 112C122 94 158 93 181 112C197 125 200 153 184 174C168 195 128 199 107 180C89 164 87 128 103 112Z" fill="url(#glow)" opacity="0.72" />
+  <path d="M113 111L138.5 171L160.5 111" fill="none" stroke="url(#ink)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M161 111V167C161 171.5 164.5 175 169 175H186" fill="none" stroke="url(#ink)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M130 147C143 135 158 134 174 144" fill="none" stroke="#e8fffb" stroke-width="7" stroke-linecap="round" opacity="0.95" />
+  <path d="M130 147C143 135 158 134 174 144" fill="none" stroke="#00d6c9" stroke-width="3.5" stroke-linecap="round" />
+
+  <text x="86" y="294" fill="#11333b" font-family="Sora, Arial, sans-serif" font-size="78" font-weight="700">Vindem Labs</text>
+  <text x="86" y="366" fill="#4f6f76" font-family="Sora, Arial, sans-serif" font-size="31">Digital products, business software, publishing platforms, and connected systems.</text>
+  <text x="86" y="456" fill="#007985" font-family="Sora, Arial, sans-serif" font-size="23" font-weight="700">PropTech | AI Education | Property Operations | IoT Integrations</text>
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -14,6 +14,11 @@
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
+    <linearGradient id="sunset" x1="20%" y1="0%" x2="82%" y2="100%">
+      <stop offset="0%" stop-color="#ffd28a" />
+      <stop offset="48%" stop-color="#f4976c" />
+      <stop offset="100%" stop-color="#df6f5e" />
+    </linearGradient>
     <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
       <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
@@ -31,8 +36,7 @@
     <path d="M110 108L141 175L168 108" stroke-width="14" />
     <path d="M175 108V162C175 171 181 177 190 177H203" stroke-width="14" />
   </g>
-  <path d="M126 186H190" fill="none" stroke="#f4976c" stroke-width="8" stroke-linecap="round" opacity="0.95" />
-  <path d="M130 183.5H186" fill="none" stroke="#fff6e8" stroke-width="2.4" stroke-linecap="round" opacity="0.62" />
+  <path d="M126 186H190" fill="none" stroke="url(#sunset)" stroke-width="8" stroke-linecap="round" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -1,38 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fbfffe" />
-      <stop offset="52%" stop-color="#effffc" />
-      <stop offset="100%" stop-color="#d9fbf7" />
+      <stop offset="0%" stop-color="#fffefd" />
+      <stop offset="50%" stop-color="#f7fbf6" />
+      <stop offset="100%" stop-color="#d7f1e9" />
     </linearGradient>
-    <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
-      <stop offset="0%" stop-color="#f4fffd" />
-      <stop offset="58%" stop-color="#bff7ef" />
-      <stop offset="100%" stop-color="#74eadf" />
+    <linearGradient id="tile" x1="7%" y1="6%" x2="93%" y2="94%">
+      <stop offset="0%" stop-color="#fff4df" />
+      <stop offset="48%" stop-color="#ccefe4" />
+      <stop offset="100%" stop-color="#68d8d1" />
     </linearGradient>
-    <linearGradient id="ink" x1="18%" y1="12%" x2="82%" y2="88%">
-      <stop offset="0%" stop-color="#00d6c9" />
-      <stop offset="100%" stop-color="#0d3440" />
-    </linearGradient>
-    <linearGradient id="glow" x1="20%" y1="18%" x2="80%" y2="82%">
-      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
-      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    <linearGradient id="mark" x1="18%" y1="12%" x2="82%" y2="88%">
+      <stop offset="0%" stop-color="#0aa6a6" />
+      <stop offset="100%" stop-color="#15313a" />
     </linearGradient>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
-  <circle cx="1030" cy="104" r="190" fill="#bff7ef" opacity="0.55" />
-  <circle cx="1032" cy="112" r="108" fill="#00d6c9" opacity="0.14" />
-  <path d="M0 518C156 488 298 499 426 548C536 590 646 588 756 546V630H0Z" fill="#74eadf" opacity="0.28" />
-  <path d="M782 0H1200V630H892C794 500 756 358 775 204C784 127 805 58 782 0Z" fill="#d0faf5" opacity="0.58" />
+  <circle cx="1012" cy="116" r="184" fill="#bfeade" opacity="0.58" />
+  <circle cx="1060" cy="142" r="82" fill="#ffb86b" opacity="0.18" />
+  <path d="M0 510C142 480 282 493 420 548C532 592 650 586 768 538V630H0Z" fill="#68d8d1" opacity="0.24" />
+  <path d="M770 0H1200V630H890C792 500 758 358 780 204C792 123 806 58 770 0Z" fill="#fff4df" opacity="0.62" />
 
-  <rect x="86" y="82" width="118" height="118" rx="34" fill="url(#tile)" />
-  <path d="M103 112C122 94 158 93 181 112C197 125 200 153 184 174C168 195 128 199 107 180C89 164 87 128 103 112Z" fill="url(#glow)" opacity="0.72" />
-  <path d="M113 111L138.5 171L160.5 111" fill="none" stroke="url(#ink)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M161 111V167C161 171.5 164.5 175 169 175H186" fill="none" stroke="url(#ink)" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
-  <path d="M130 147C143 135 158 134 174 144" fill="none" stroke="#e8fffb" stroke-width="7" stroke-linecap="round" opacity="0.95" />
-  <path d="M130 147C143 135 158 134 174 144" fill="none" stroke="#00d6c9" stroke-width="3.5" stroke-linecap="round" />
+  <rect x="86" y="82" width="118" height="118" rx="32" fill="url(#tile)" />
+  <path d="M105 113C119 96 152 93 178 111C197 124 202 153 184 176C166 198 127 199 106 179C88 162 88 132 105 113Z" fill="#ffffff" opacity="0.58" />
+  <path d="M111 112H126L141.5 169L158.5 112H173L150.2 176H133.8L111 112Z" fill="url(#mark)" />
+  <path d="M160 112H175V163H188V176H160V112Z" fill="#15313a" opacity="0.92" />
+  <path d="M122 144C137 132 154 132 174 144" fill="none" stroke="#fff4df" stroke-width="8" stroke-linecap="round" />
+  <circle cx="174" cy="121" r="6.2" fill="#ffb86b" />
 
-  <text x="86" y="294" fill="#11333b" font-family="Sora, Arial, sans-serif" font-size="78" font-weight="700">Vindem Labs</text>
-  <text x="86" y="366" fill="#4f6f76" font-family="Sora, Arial, sans-serif" font-size="31">Digital products, business software, publishing platforms, and connected systems.</text>
-  <text x="86" y="456" fill="#007985" font-family="Sora, Arial, sans-serif" font-size="23" font-weight="700">PropTech | AI Education | Property Operations | IoT Integrations</text>
+  <text x="86" y="294" fill="#15313a" font-family="Sora, Arial, sans-serif" font-size="78" font-weight="700">Vindem Labs</text>
+  <text x="86" y="366" fill="#557178" font-family="Sora, Arial, sans-serif" font-size="31">Digital products, business software, publishing platforms, and connected systems.</text>
+  <text x="86" y="456" fill="#0b5f68" font-family="Sora, Arial, sans-serif" font-size="23" font-weight="700">PropTech | AI Education | Property Operations | IoT Integrations</text>
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -31,8 +31,8 @@
     <path d="M110 108L141 175L168 108" stroke-width="14" />
     <path d="M175 108V162C175 171 181 177 190 177H203" stroke-width="14" />
   </g>
-  <path d="M132 148C146 135 163 135 182 146" fill="none" stroke="#f4976c" stroke-width="7" stroke-linecap="round" opacity="0.95" />
-  <path d="M132 148C146 135 163 135 182 146" fill="none" stroke="#fff6e8" stroke-width="2.4" stroke-linecap="round" opacity="0.7" />
+  <path d="M126 186H190" fill="none" stroke="#f4976c" stroke-width="8" stroke-linecap="round" opacity="0.95" />
+  <path d="M130 183.5H186" fill="none" stroke="#fff6e8" stroke-width="2.4" stroke-linecap="round" opacity="0.62" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -7,15 +7,15 @@
     </linearGradient>
     <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
       <stop offset="0%" stop-color="#fff6e8" />
-      <stop offset="52%" stop-color="#d7f8f0" />
+      <stop offset="55%" stop-color="#d7f8f0" />
       <stop offset="100%" stop-color="#6ddbd5" />
     </linearGradient>
-    <linearGradient id="ink" x1="20%" y1="12%" x2="82%" y2="88%">
+    <linearGradient id="ink" x1="16%" y1="12%" x2="84%" y2="88%">
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <filter id="soft-shadow" x="-18%" y="-18%" width="136%" height="136%">
-      <feDropShadow dx="0" dy="9" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
+    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
+      <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
@@ -26,13 +26,13 @@
   <path d="M970 390C1016 348 1084 348 1138 390" fill="none" stroke="#00a7b3" stroke-width="22" stroke-linecap="round" opacity="0.18" />
 
   <rect x="86" y="78" width="124" height="124" rx="38" fill="url(#tile)" />
-  <path d="M101 111C118 91 153 89 180 106C199 119 206 143 195 165C184 188 156 199 127 189C104 181 90 159 92 135C93 125 94 117 101 111Z" fill="#ffffff" opacity="0.58" />
-  <g filter="url(#soft-shadow)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M111 108L142 176L173 108" stroke-width="14" />
-    <path d="M179 108V162C179 171 185 177 194 177H204" stroke-width="14" />
+  <path d="M101 111C118 91 153 89 180 106C199 119 206 143 195 165C184 188 156 199 127 189C104 181 90 159 92 135C93 125 94 117 101 111Z" fill="#ffffff" opacity="0.64" />
+  <g filter="url(#lift)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M110 108L141 175L168 108" stroke-width="14" />
+    <path d="M175 108V162C175 171 181 177 190 177H203" stroke-width="14" />
   </g>
-  <path d="M124 111L143 153L162 111" fill="none" stroke="#eafffb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.82" />
-  <path d="M190 111V157C190 160 192 162 195 162H202" fill="none" stroke="#eafffb" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.7" />
+  <path d="M132 148C146 135 163 135 182 146" fill="none" stroke="#f4976c" stroke-width="7" stroke-linecap="round" opacity="0.95" />
+  <path d="M132 148C146 135 163 135 182 146" fill="none" stroke="#fff6e8" stroke-width="2.4" stroke-linecap="round" opacity="0.7" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -14,10 +14,10 @@
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <linearGradient id="sunset" x1="20%" y1="0%" x2="82%" y2="100%">
-      <stop offset="0%" stop-color="#ffd28a" />
-      <stop offset="48%" stop-color="#f4976c" />
-      <stop offset="100%" stop-color="#df6f5e" />
+    <linearGradient id="sunset" x1="116" y1="184" x2="204" y2="194" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#ffd26f" />
+      <stop offset="42%" stop-color="#ff9f4a" />
+      <stop offset="100%" stop-color="#d95f52" />
     </linearGradient>
     <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
       <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
@@ -36,7 +36,7 @@
     <path d="M110 108L141 175L168 108" stroke-width="14" />
     <path d="M175 108V162C175 171 181 177 190 177H203" stroke-width="14" />
   </g>
-  <path d="M126 186H190" fill="none" stroke="url(#sunset)" stroke-width="8" stroke-linecap="round" />
+  <rect x="116" y="184" width="88" height="12" rx="6" fill="url(#sunset)" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/index.html
+++ b/index.html
@@ -8,33 +8,34 @@
       name="description"
       content="Vindem Labs designs and builds consumer apps, enterprise software, websites, and digital platforms across PropTech, AI education, property operations, and IoT."
     />
-    <meta name="theme-color" content="#d7f1e9" />
+    <meta name="theme-color" content="#d9f4f1" />
     <meta property="og:title" content="Vindem Labs" />
     <meta
       property="og:description"
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg" />
+    <meta property="og:image" content="assets/og-card.svg?v=3" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=3" type="image/svg+xml" />
     <style>
       :root {
-        --bg: #f7fbf6;
-        --bg-deep: #d7f1e9;
+        --bg: #f5fbf8;
+        --bg-deep: #d9f4f1;
         --panel: rgba(255, 255, 255, 0.8);
         --panel-strong: rgba(255, 255, 255, 0.96);
-        --text: #15313a;
-        --muted: #557178;
-        --line: rgba(21, 49, 58, 0.1);
-        --brand: #0aa6a6;
-        --brand-deep: #0b5f68;
-        --brand-soft: #bfeade;
-        --accent: #ffb86b;
-        --ink: #263d43;
-        --cream: #fff4df;
-        --shadow: 0 18px 42px rgba(12, 82, 92, 0.1);
-        --shadow-strong: 0 28px 70px rgba(12, 82, 92, 0.16);
+        --text: #133138;
+        --muted: #55747b;
+        --line: rgba(19, 49, 56, 0.1);
+        --brand: #00a7b3;
+        --brand-deep: #07545d;
+        --brand-soft: #beece7;
+        --accent: #f4976c;
+        --ink: #213e44;
+        --cream: #fff2dc;
+        --mint: #dff8ef;
+        --shadow: 0 18px 42px rgba(7, 84, 93, 0.1);
+        --shadow-strong: 0 28px 70px rgba(7, 84, 93, 0.16);
         --radius: 22px;
         --max: 1180px;
       }
@@ -53,10 +54,10 @@
         color: var(--text);
         overflow-x: hidden;
         background:
-          radial-gradient(circle at 8% 12%, rgba(255, 244, 223, 0.88), transparent 24rem),
-          radial-gradient(circle at 88% 8%, rgba(10, 166, 166, 0.18), transparent 25rem),
-          radial-gradient(circle at 18% 92%, rgba(255, 184, 107, 0.13), transparent 28rem),
-          linear-gradient(180deg, #fffefd 0%, var(--bg) 48%, var(--bg-deep) 100%);
+          radial-gradient(circle at 7% 10%, rgba(255, 242, 220, 0.9), transparent 25rem),
+          radial-gradient(circle at 88% 8%, rgba(0, 167, 179, 0.18), transparent 25rem),
+          radial-gradient(circle at 18% 92%, rgba(244, 151, 108, 0.14), transparent 28rem),
+          linear-gradient(180deg, #fffefd 0%, var(--bg) 46%, var(--bg-deep) 100%);
       }
 
       body::before {
@@ -68,7 +69,7 @@
         transform: translateX(12%);
         border-radius: 38% 62% 44% 56%;
         background:
-          linear-gradient(135deg, rgba(10, 166, 166, 0.18), rgba(255, 184, 107, 0.16)),
+          linear-gradient(135deg, rgba(0, 167, 179, 0.18), rgba(244, 151, 108, 0.16)),
           radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.88), transparent 34%);
         filter: blur(2px);
         opacity: 0.72;
@@ -103,8 +104,8 @@
         top: 0;
         z-index: 20;
         backdrop-filter: blur(18px);
-        background: rgba(247, 251, 246, 0.8);
-        border-bottom: 1px solid rgba(21, 49, 58, 0.06);
+        background: rgba(245, 251, 248, 0.82);
+        border-bottom: 1px solid rgba(19, 49, 56, 0.06);
       }
 
       .site-header .shell {
@@ -128,7 +129,7 @@
         width: 2.7rem;
         height: 2.7rem;
         border-radius: 0.95rem;
-        box-shadow: 0 8px 22px rgba(11, 95, 104, 0.18);
+        box-shadow: 0 8px 22px rgba(7, 84, 93, 0.18);
         overflow: hidden;
         flex: 0 0 auto;
       }
@@ -180,12 +181,12 @@
       }
 
       .mobile-nav[open] summary {
-        border-color: rgba(10, 166, 166, 0.42);
-        background: rgba(191, 234, 222, 0.5);
+        border-color: rgba(0, 167, 179, 0.42);
+        background: rgba(190, 236, 231, 0.5);
       }
 
       .mobile-nav summary:focus-visible {
-        outline: 2px solid rgba(10, 166, 166, 0.35);
+        outline: 2px solid rgba(0, 167, 179, 0.35);
         outline-offset: 3px;
       }
 
@@ -215,8 +216,8 @@
 
       .mobile-nav-panel a:hover,
       .mobile-nav-panel a:focus-visible {
-        background: rgba(191, 234, 222, 0.5);
-        outline: 2px solid rgba(10, 166, 166, 0.25);
+        background: rgba(190, 236, 231, 0.5);
+        outline: 2px solid rgba(0, 167, 179, 0.25);
         outline-offset: 2px;
       }
 
@@ -271,8 +272,8 @@
 
       .hero-grid {
         display: grid;
-        grid-template-columns: minmax(0, 1.08fr) minmax(340px, 0.92fr);
-        gap: 2rem;
+        grid-template-columns: minmax(0, 1.04fr) minmax(360px, 0.96fr);
+        gap: clamp(1.5rem, 4vw, 3.25rem);
         align-items: center;
       }
 
@@ -291,7 +292,7 @@
         font-weight: 800;
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        background: rgba(10, 166, 166, 0.16);
+        background: linear-gradient(135deg, rgba(0, 167, 179, 0.16), rgba(255, 242, 220, 0.78));
         color: var(--brand-deep);
       }
 
@@ -307,7 +308,7 @@
         line-height: 1;
         letter-spacing: 0;
         max-width: 13ch;
-        background: linear-gradient(120deg, #15313a 0%, #0b5f68 56%, #ff9f4a 118%);
+        background: linear-gradient(120deg, #133138 0%, #07545d 52%, #e97f59 116%);
         -webkit-background-clip: text;
         background-clip: text;
         color: transparent;
@@ -338,13 +339,13 @@
 
       .hero-proof span {
         padding: 0.55rem 0.75rem;
-        border: 1px solid rgba(8, 127, 140, 0.12);
+        border: 1px solid rgba(0, 126, 139, 0.12);
         border-radius: 0.75rem;
         background: rgba(255, 255, 255, 0.54);
         color: var(--ink);
         font-size: 0.86rem;
         font-weight: 700;
-        box-shadow: 0 10px 24px rgba(12, 82, 92, 0.06);
+        box-shadow: 0 10px 24px rgba(7, 84, 93, 0.06);
       }
 
       .metric-row {
@@ -374,6 +375,7 @@
         padding: 1.15rem;
         position: relative;
         overflow: hidden;
+        transition: transform 180ms ease, box-shadow 180ms ease;
       }
 
       .metric-card::before {
@@ -382,6 +384,11 @@
         inset: 0 0 auto;
         height: 4px;
         background: linear-gradient(90deg, var(--brand), var(--accent));
+      }
+
+      .metric-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 18px 38px rgba(7, 84, 93, 0.1);
       }
 
       .metric-card strong {
@@ -397,12 +404,12 @@
 
       .glass-card {
         border-radius: var(--radius);
-        padding: 1.7rem;
+        padding: clamp(1.2rem, 2.4vw, 1.85rem);
         position: relative;
         overflow: hidden;
         background:
-          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(236, 248, 242, 0.84)),
-          radial-gradient(circle at 92% 8%, rgba(255, 184, 107, 0.18), transparent 11rem);
+          linear-gradient(145deg, rgba(255, 255, 255, 0.97), rgba(223, 248, 239, 0.86)),
+          radial-gradient(circle at 92% 8%, rgba(244, 151, 108, 0.18), transparent 11rem);
         border-color: rgba(255, 255, 255, 0.9);
         box-shadow: var(--shadow-strong);
       }
@@ -413,7 +420,22 @@
         inset: 0;
         background:
           linear-gradient(135deg, rgba(255, 255, 255, 0.7), transparent 42%),
-          repeating-linear-gradient(135deg, rgba(8, 127, 140, 0.045) 0 1px, transparent 1px 16px);
+          repeating-linear-gradient(135deg, rgba(0, 126, 139, 0.045) 0 1px, transparent 1px 16px);
+        pointer-events: none;
+      }
+
+      .glass-card::after {
+        content: "";
+        position: absolute;
+        width: 11rem;
+        height: 11rem;
+        right: -4.5rem;
+        bottom: -4.2rem;
+        border-radius: 50%;
+        background:
+          radial-gradient(circle, rgba(255, 255, 255, 0.7) 0 34%, transparent 35%),
+          conic-gradient(from 120deg, rgba(0, 167, 179, 0.28), rgba(244, 151, 108, 0.22), rgba(0, 167, 179, 0.28));
+        opacity: 0.72;
         pointer-events: none;
       }
 
@@ -421,6 +443,7 @@
         display: grid;
         gap: 1.1rem;
         align-self: stretch;
+        align-content: center;
       }
 
       .hero-board > * {
@@ -456,22 +479,26 @@
 
       .delivery-list {
         display: grid;
-        gap: 0.7rem;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 0.82rem;
       }
 
       .delivery-item {
         display: grid;
-        grid-template-columns: 2.7rem minmax(0, 1fr);
-        gap: 0.95rem;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0.75rem;
         align-items: start;
-        padding: 0.9rem;
-        border: 1px solid rgba(21, 49, 58, 0.07);
-        border-radius: 1rem;
-        background: rgba(255, 255, 255, 0.62);
+        padding: 1rem;
+        border: 1px solid rgba(19, 49, 56, 0.07);
+        border-radius: 1.15rem;
+        background:
+          linear-gradient(160deg, rgba(255, 255, 255, 0.76), rgba(255, 255, 255, 0.42)),
+          radial-gradient(circle at 90% 0%, rgba(190, 236, 231, 0.54), transparent 7rem);
+        min-height: 9.35rem;
       }
 
       .delivery-item:first-child {
-        border-top: 1px solid rgba(21, 49, 58, 0.07);
+        border-top: 1px solid rgba(19, 49, 56, 0.07);
       }
 
       .delivery-item .delivery-code {
@@ -480,7 +507,7 @@
         width: 2.2rem;
         height: 2.2rem;
         border-radius: 0.75rem;
-        background: linear-gradient(145deg, rgba(10, 166, 166, 0.18), rgba(255, 184, 107, 0.16));
+        background: linear-gradient(145deg, rgba(0, 167, 179, 0.18), rgba(244, 151, 108, 0.16));
         color: var(--brand-deep);
         font-size: 0.78rem;
         font-weight: 800;
@@ -492,8 +519,11 @@
       }
 
       .delivery-note {
-        border-left: 3px solid var(--accent);
-        padding-left: 1rem;
+        border: 1px solid rgba(244, 151, 108, 0.24);
+        border-left: 4px solid var(--accent);
+        border-radius: 1rem;
+        padding: 0.95rem 1rem;
+        background: rgba(255, 242, 220, 0.55);
         color: var(--ink);
         font-weight: 700;
       }
@@ -503,7 +533,7 @@
         padding: 0.6rem 0.85rem;
         border-radius: 0.7rem;
         font-size: 0.88rem;
-        background: rgba(21, 49, 58, 0.06);
+        background: rgba(19, 49, 56, 0.06);
       }
 
       .section-head {
@@ -558,8 +588,8 @@
       .stream-tab:focus-visible,
       .stream-tab[aria-selected="true"] {
         transform: translateX(4px);
-        border-color: rgba(10, 166, 166, 0.42);
-        background: rgba(191, 234, 222, 0.5);
+        border-color: rgba(0, 167, 179, 0.42);
+        background: rgba(190, 236, 231, 0.5);
       }
 
       .stream-tab strong {
@@ -578,6 +608,9 @@
         min-height: 468px;
         border-radius: 1.75rem;
         padding: 1.5rem;
+        background:
+          linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(245, 251, 248, 0.74)),
+          radial-gradient(circle at 100% 0%, rgba(190, 236, 231, 0.72), transparent 15rem);
       }
 
       .stream-panel[hidden] {
@@ -600,7 +633,7 @@
       .stream-badge {
         padding: 0.45rem 0.7rem;
         border-radius: 0.7rem;
-        background: rgba(10, 166, 166, 0.13);
+        background: rgba(0, 167, 179, 0.13);
         color: var(--brand-deep);
         white-space: nowrap;
         font-size: 0.82rem;
@@ -629,8 +662,8 @@
       .quote-card {
         padding: 1rem;
         border-radius: 0.8rem;
-        background: rgba(21, 49, 58, 0.04);
-        border: 1px solid rgba(21, 49, 58, 0.06);
+        background: rgba(19, 49, 56, 0.04);
+        border: 1px solid rgba(19, 49, 56, 0.06);
       }
 
       .sub-item strong,
@@ -662,6 +695,15 @@
       .contact-form {
         border-radius: 1.5rem;
         padding: 1.35rem;
+        transition: transform 180ms ease, box-shadow 180ms ease;
+      }
+
+      .path-card:hover,
+      .pillar:hover,
+      .timeline-card:hover,
+      .quote-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 20px 44px rgba(7, 84, 93, 0.11);
       }
 
       .path-card em {
@@ -742,9 +784,9 @@
 
       .field input:focus-visible,
       .field textarea:focus-visible {
-        outline: 2px solid rgba(10, 166, 166, 0.25);
+        outline: 2px solid rgba(0, 167, 179, 0.25);
         outline-offset: 1px;
-        border-color: rgba(10, 166, 166, 0.46);
+        border-color: rgba(0, 167, 179, 0.46);
       }
 
       .form-meta {
@@ -856,6 +898,7 @@
         .delivery-item {
           grid-template-columns: 1fr;
           gap: 0.25rem;
+          min-height: auto;
         }
 
         .glass-card,
@@ -876,7 +919,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg" alt="" />
+            <img src="assets/favicon.svg?v=3" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs
@@ -1010,7 +1053,7 @@
           </div>
 
           <div class="stream-shell">
-            <div class="stream-tabs" role="tablist" aria-label="Revenue stream tabs">
+            <div class="stream-tabs" role="tablist" aria-label="Offering tabs">
               <button class="stream-tab" role="tab" aria-selected="true" aria-controls="stream-consumer" id="tab-consumer">
                 <strong>Consumer applications</strong>
                 <span>Web and mobile products built for direct user engagement and growth.</span>
@@ -1479,7 +1522,7 @@
     <footer>
       <div class="shell footer-bar">
         <span>Vindem Labs</span>
-        <span>Digital products, intelligent systems, and modern revenue infrastructure.</span>
+        <span>Digital products, connected systems, and modern web platforms.</span>
       </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=6" />
+    <meta property="og:image" content="assets/og-card.svg?v=7" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=6" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=7" type="image/svg+xml" />
     <style>
       :root {
         --bg: #f5fbf8;
@@ -912,7 +912,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=6" alt="" />
+            <img src="assets/favicon.svg?v=7" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=7" />
+    <meta property="og:image" content="assets/og-card.svg?v=8" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=7" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=8" type="image/svg+xml" />
     <style>
       :root {
         --bg: #f5fbf8;
@@ -912,7 +912,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=7" alt="" />
+            <img src="assets/favicon.svg?v=8" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Vindem Labs designs and builds consumer apps, enterprise software, websites, and digital platforms across PropTech, AI education, property operations, and IoT."
     />
-    <meta name="theme-color" content="#d9fbf7" />
+    <meta name="theme-color" content="#d7f1e9" />
     <meta property="og:title" content="Vindem Labs" />
     <meta
       property="og:description"
@@ -20,21 +20,21 @@
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <style>
       :root {
-        --bg: #f1fffc;
-        --bg-deep: #d9fbf7;
+        --bg: #f7fbf6;
+        --bg-deep: #d7f1e9;
         --panel: rgba(255, 255, 255, 0.8);
         --panel-strong: rgba(255, 255, 255, 0.96);
-        --text: #11333b;
-        --muted: #4f6f76;
-        --line: rgba(17, 51, 59, 0.1);
-        --brand: #00d6c9;
-        --brand-deep: #007985;
-        --brand-soft: #bff7ef;
-        --accent: #57e5d5;
-        --ink: #1f4650;
-        --cream: #effffc;
-        --shadow: 0 18px 42px rgba(0, 105, 118, 0.1);
-        --shadow-strong: 0 28px 70px rgba(0, 105, 118, 0.16);
+        --text: #15313a;
+        --muted: #557178;
+        --line: rgba(21, 49, 58, 0.1);
+        --brand: #0aa6a6;
+        --brand-deep: #0b5f68;
+        --brand-soft: #bfeade;
+        --accent: #ffb86b;
+        --ink: #263d43;
+        --cream: #fff4df;
+        --shadow: 0 18px 42px rgba(12, 82, 92, 0.1);
+        --shadow-strong: 0 28px 70px rgba(12, 82, 92, 0.16);
         --radius: 22px;
         --max: 1180px;
       }
@@ -53,10 +53,10 @@
         color: var(--text);
         overflow-x: hidden;
         background:
-          radial-gradient(circle at 8% 12%, rgba(218, 255, 249, 0.95), transparent 24rem),
-          radial-gradient(circle at 88% 8%, rgba(0, 214, 201, 0.2), transparent 25rem),
-          radial-gradient(circle at 18% 92%, rgba(87, 229, 213, 0.16), transparent 28rem),
-          linear-gradient(180deg, #fbfffe 0%, var(--bg) 48%, var(--bg-deep) 100%);
+          radial-gradient(circle at 8% 12%, rgba(255, 244, 223, 0.88), transparent 24rem),
+          radial-gradient(circle at 88% 8%, rgba(10, 166, 166, 0.18), transparent 25rem),
+          radial-gradient(circle at 18% 92%, rgba(255, 184, 107, 0.13), transparent 28rem),
+          linear-gradient(180deg, #fffefd 0%, var(--bg) 48%, var(--bg-deep) 100%);
       }
 
       body::before {
@@ -68,7 +68,7 @@
         transform: translateX(12%);
         border-radius: 38% 62% 44% 56%;
         background:
-          linear-gradient(135deg, rgba(0, 214, 201, 0.2), rgba(0, 121, 133, 0.1)),
+          linear-gradient(135deg, rgba(10, 166, 166, 0.18), rgba(255, 184, 107, 0.16)),
           radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.88), transparent 34%);
         filter: blur(2px);
         opacity: 0.72;
@@ -103,8 +103,8 @@
         top: 0;
         z-index: 20;
         backdrop-filter: blur(18px);
-        background: rgba(241, 255, 252, 0.78);
-        border-bottom: 1px solid rgba(17, 51, 59, 0.06);
+        background: rgba(247, 251, 246, 0.8);
+        border-bottom: 1px solid rgba(21, 49, 58, 0.06);
       }
 
       .site-header .shell {
@@ -128,7 +128,7 @@
         width: 2.7rem;
         height: 2.7rem;
         border-radius: 0.95rem;
-        box-shadow: 0 8px 22px rgba(0, 121, 133, 0.18);
+        box-shadow: 0 8px 22px rgba(11, 95, 104, 0.18);
         overflow: hidden;
         flex: 0 0 auto;
       }
@@ -180,12 +180,12 @@
       }
 
       .mobile-nav[open] summary {
-        border-color: rgba(0, 214, 201, 0.42);
-        background: rgba(191, 247, 239, 0.5);
+        border-color: rgba(10, 166, 166, 0.42);
+        background: rgba(191, 234, 222, 0.5);
       }
 
       .mobile-nav summary:focus-visible {
-        outline: 2px solid rgba(0, 214, 201, 0.35);
+        outline: 2px solid rgba(10, 166, 166, 0.35);
         outline-offset: 3px;
       }
 
@@ -215,8 +215,8 @@
 
       .mobile-nav-panel a:hover,
       .mobile-nav-panel a:focus-visible {
-        background: rgba(191, 247, 239, 0.5);
-        outline: 2px solid rgba(0, 214, 201, 0.25);
+        background: rgba(191, 234, 222, 0.5);
+        outline: 2px solid rgba(10, 166, 166, 0.25);
         outline-offset: 2px;
       }
 
@@ -291,7 +291,7 @@
         font-weight: 800;
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        background: rgba(0, 214, 201, 0.16);
+        background: rgba(10, 166, 166, 0.16);
         color: var(--brand-deep);
       }
 
@@ -307,7 +307,7 @@
         line-height: 1;
         letter-spacing: 0;
         max-width: 13ch;
-        background: linear-gradient(120deg, #11333b 0%, #007985 55%, #00cfc2 112%);
+        background: linear-gradient(120deg, #15313a 0%, #0b5f68 56%, #ff9f4a 118%);
         -webkit-background-clip: text;
         background-clip: text;
         color: transparent;
@@ -344,7 +344,7 @@
         color: var(--ink);
         font-size: 0.86rem;
         font-weight: 700;
-        box-shadow: 0 10px 24px rgba(0, 105, 118, 0.06);
+        box-shadow: 0 10px 24px rgba(12, 82, 92, 0.06);
       }
 
       .metric-row {
@@ -401,8 +401,8 @@
         position: relative;
         overflow: hidden;
         background:
-          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(222, 253, 248, 0.82)),
-          radial-gradient(circle at 92% 8%, rgba(0, 214, 201, 0.18), transparent 11rem);
+          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(236, 248, 242, 0.84)),
+          radial-gradient(circle at 92% 8%, rgba(255, 184, 107, 0.18), transparent 11rem);
         border-color: rgba(255, 255, 255, 0.9);
         box-shadow: var(--shadow-strong);
       }
@@ -465,13 +465,13 @@
         gap: 0.95rem;
         align-items: start;
         padding: 0.9rem;
-        border: 1px solid rgba(17, 51, 59, 0.07);
+        border: 1px solid rgba(21, 49, 58, 0.07);
         border-radius: 1rem;
         background: rgba(255, 255, 255, 0.62);
       }
 
       .delivery-item:first-child {
-        border-top: 1px solid rgba(17, 51, 59, 0.07);
+        border-top: 1px solid rgba(21, 49, 58, 0.07);
       }
 
       .delivery-item .delivery-code {
@@ -480,7 +480,7 @@
         width: 2.2rem;
         height: 2.2rem;
         border-radius: 0.75rem;
-        background: linear-gradient(145deg, rgba(0, 214, 201, 0.18), rgba(0, 121, 133, 0.12));
+        background: linear-gradient(145deg, rgba(10, 166, 166, 0.18), rgba(255, 184, 107, 0.16));
         color: var(--brand-deep);
         font-size: 0.78rem;
         font-weight: 800;
@@ -503,7 +503,7 @@
         padding: 0.6rem 0.85rem;
         border-radius: 0.7rem;
         font-size: 0.88rem;
-        background: rgba(17, 51, 59, 0.06);
+        background: rgba(21, 49, 58, 0.06);
       }
 
       .section-head {
@@ -558,8 +558,8 @@
       .stream-tab:focus-visible,
       .stream-tab[aria-selected="true"] {
         transform: translateX(4px);
-        border-color: rgba(0, 214, 201, 0.42);
-        background: rgba(191, 247, 239, 0.5);
+        border-color: rgba(10, 166, 166, 0.42);
+        background: rgba(191, 234, 222, 0.5);
       }
 
       .stream-tab strong {
@@ -600,7 +600,7 @@
       .stream-badge {
         padding: 0.45rem 0.7rem;
         border-radius: 0.7rem;
-        background: rgba(0, 214, 201, 0.13);
+        background: rgba(10, 166, 166, 0.13);
         color: var(--brand-deep);
         white-space: nowrap;
         font-size: 0.82rem;
@@ -629,8 +629,8 @@
       .quote-card {
         padding: 1rem;
         border-radius: 0.8rem;
-        background: rgba(17, 51, 59, 0.04);
-        border: 1px solid rgba(17, 51, 59, 0.06);
+        background: rgba(21, 49, 58, 0.04);
+        border: 1px solid rgba(21, 49, 58, 0.06);
       }
 
       .sub-item strong,
@@ -742,9 +742,9 @@
 
       .field input:focus-visible,
       .field textarea:focus-visible {
-        outline: 2px solid rgba(0, 214, 201, 0.25);
+        outline: 2px solid rgba(10, 166, 166, 0.25);
         outline-offset: 1px;
-        border-color: rgba(0, 214, 201, 0.46);
+        border-color: rgba(10, 166, 166, 0.46);
       }
 
       .form-meta {

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=3" />
+    <meta property="og:image" content="assets/og-card.svg?v=4" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=3" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=4" type="image/svg+xml" />
     <style>
       :root {
         --bg: #f5fbf8;
@@ -919,7 +919,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=3" alt="" />
+            <img src="assets/favicon.svg?v=4" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=4" />
+    <meta property="og:image" content="assets/og-card.svg?v=5" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=4" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=5" type="image/svg+xml" />
     <style>
       :root {
         --bg: #f5fbf8;
@@ -250,11 +250,11 @@
       }
 
       main section {
-        padding: 4.25rem 0;
+        padding: 3.65rem 0;
       }
 
       .hero {
-        padding-top: 4rem;
+        padding-top: 3.25rem;
         position: relative;
       }
 
@@ -274,7 +274,7 @@
         display: grid;
         grid-template-columns: minmax(0, 1.04fr) minmax(360px, 0.96fr);
         gap: clamp(1.5rem, 4vw, 3.25rem);
-        align-items: center;
+        align-items: start;
       }
 
       .hero-copy {
@@ -404,7 +404,7 @@
 
       .glass-card {
         border-radius: var(--radius);
-        padding: clamp(1.2rem, 2.4vw, 1.85rem);
+        padding: clamp(1.35rem, 2.4vw, 1.85rem);
         position: relative;
         overflow: hidden;
         background:
@@ -441,9 +441,9 @@
 
       .hero-board {
         display: grid;
-        gap: 1.1rem;
+        gap: 1rem;
         align-self: stretch;
-        align-content: center;
+        align-content: start;
       }
 
       .hero-board > * {
@@ -479,22 +479,18 @@
 
       .delivery-list {
         display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 0.82rem;
+        gap: 0.7rem;
       }
 
       .delivery-item {
         display: grid;
-        grid-template-columns: minmax(0, 1fr);
-        gap: 0.75rem;
+        grid-template-columns: 2.7rem minmax(0, 1fr);
+        gap: 0.95rem;
         align-items: start;
-        padding: 1rem;
+        padding: 0.9rem;
         border: 1px solid rgba(19, 49, 56, 0.07);
-        border-radius: 1.15rem;
-        background:
-          linear-gradient(160deg, rgba(255, 255, 255, 0.76), rgba(255, 255, 255, 0.42)),
-          radial-gradient(circle at 90% 0%, rgba(190, 236, 231, 0.54), transparent 7rem);
-        min-height: 9.35rem;
+        border-radius: 1rem;
+        background: rgba(255, 255, 255, 0.62);
       }
 
       .delivery-item:first-child {
@@ -519,11 +515,8 @@
       }
 
       .delivery-note {
-        border: 1px solid rgba(244, 151, 108, 0.24);
-        border-left: 4px solid var(--accent);
-        border-radius: 1rem;
-        padding: 0.95rem 1rem;
-        background: rgba(255, 242, 220, 0.55);
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
         color: var(--ink);
         font-weight: 700;
       }
@@ -541,7 +534,7 @@
         grid-template-columns: 0.92fr 1fr;
         gap: 1.4rem;
         align-items: end;
-        margin-bottom: 1.8rem;
+        margin-bottom: 1.55rem;
       }
 
       .section-head h2 {
@@ -694,7 +687,7 @@
       .contact-card,
       .contact-form {
         border-radius: 1.5rem;
-        padding: 1.35rem;
+        padding: 1.25rem;
         transition: transform 180ms ease, box-shadow 180ms ease;
       }
 
@@ -858,7 +851,7 @@
 
       @media (max-width: 640px) {
         main section {
-          padding: 3.4rem 0;
+          padding: 2.9rem 0;
         }
 
         .site-header .shell {
@@ -919,7 +912,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=4" alt="" />
+            <img src="assets/favicon.svg?v=5" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=5" />
+    <meta property="og:image" content="assets/og-card.svg?v=6" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=5" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=6" type="image/svg+xml" />
     <style>
       :root {
         --bg: #f5fbf8;
@@ -912,7 +912,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=5" alt="" />
+            <img src="assets/favicon.svg?v=6" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       name="description"
       content="Vindem Labs designs and builds consumer apps, enterprise software, websites, and digital platforms across PropTech, AI education, property operations, and IoT."
     />
-    <meta name="theme-color" content="#dff8f4" />
+    <meta name="theme-color" content="#d9fbf7" />
     <meta property="og:title" content="Vindem Labs" />
     <meta
       property="og:description"
@@ -20,21 +20,21 @@
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml" />
     <style>
       :root {
-        --bg: #f4fbfa;
-        --bg-deep: #dff7f4;
-        --panel: rgba(255, 255, 255, 0.82);
-        --panel-strong: rgba(255, 255, 255, 0.94);
-        --text: #172f35;
-        --muted: #546b71;
-        --line: rgba(22, 51, 58, 0.1);
-        --brand: #18bfc0;
-        --brand-deep: #087f8c;
-        --brand-soft: #caefea;
-        --accent: #f2b36d;
-        --ink: #24404a;
-        --cream: #fff8ec;
-        --shadow: 0 18px 42px rgba(24, 71, 79, 0.1);
-        --shadow-strong: 0 28px 70px rgba(24, 71, 79, 0.16);
+        --bg: #f1fffc;
+        --bg-deep: #d9fbf7;
+        --panel: rgba(255, 255, 255, 0.8);
+        --panel-strong: rgba(255, 255, 255, 0.96);
+        --text: #11333b;
+        --muted: #4f6f76;
+        --line: rgba(17, 51, 59, 0.1);
+        --brand: #00d6c9;
+        --brand-deep: #007985;
+        --brand-soft: #bff7ef;
+        --accent: #57e5d5;
+        --ink: #1f4650;
+        --cream: #effffc;
+        --shadow: 0 18px 42px rgba(0, 105, 118, 0.1);
+        --shadow-strong: 0 28px 70px rgba(0, 105, 118, 0.16);
         --radius: 22px;
         --max: 1180px;
       }
@@ -53,10 +53,10 @@
         color: var(--text);
         overflow-x: hidden;
         background:
-          radial-gradient(circle at 8% 12%, rgba(255, 248, 236, 0.95), transparent 24rem),
-          radial-gradient(circle at 88% 8%, rgba(24, 191, 192, 0.18), transparent 25rem),
-          linear-gradient(120deg, rgba(242, 179, 109, 0.12), transparent 34%),
-          linear-gradient(180deg, #fbfefe 0%, var(--bg) 48%, var(--bg-deep) 100%);
+          radial-gradient(circle at 8% 12%, rgba(218, 255, 249, 0.95), transparent 24rem),
+          radial-gradient(circle at 88% 8%, rgba(0, 214, 201, 0.2), transparent 25rem),
+          radial-gradient(circle at 18% 92%, rgba(87, 229, 213, 0.16), transparent 28rem),
+          linear-gradient(180deg, #fbfffe 0%, var(--bg) 48%, var(--bg-deep) 100%);
       }
 
       body::before {
@@ -68,7 +68,7 @@
         transform: translateX(12%);
         border-radius: 38% 62% 44% 56%;
         background:
-          linear-gradient(135deg, rgba(24, 191, 192, 0.16), rgba(242, 179, 109, 0.14)),
+          linear-gradient(135deg, rgba(0, 214, 201, 0.2), rgba(0, 121, 133, 0.1)),
           radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.88), transparent 34%);
         filter: blur(2px);
         opacity: 0.72;
@@ -103,8 +103,8 @@
         top: 0;
         z-index: 20;
         backdrop-filter: blur(18px);
-        background: rgba(239, 250, 248, 0.76);
-        border-bottom: 1px solid rgba(22, 51, 58, 0.05);
+        background: rgba(241, 255, 252, 0.78);
+        border-bottom: 1px solid rgba(17, 51, 59, 0.06);
       }
 
       .site-header .shell {
@@ -128,7 +128,7 @@
         width: 2.7rem;
         height: 2.7rem;
         border-radius: 0.95rem;
-        box-shadow: 0 8px 22px rgba(29, 158, 167, 0.18);
+        box-shadow: 0 8px 22px rgba(0, 121, 133, 0.18);
         overflow: hidden;
         flex: 0 0 auto;
       }
@@ -180,12 +180,12 @@
       }
 
       .mobile-nav[open] summary {
-        border-color: rgba(76, 207, 197, 0.42);
-        background: rgba(191, 244, 239, 0.5);
+        border-color: rgba(0, 214, 201, 0.42);
+        background: rgba(191, 247, 239, 0.5);
       }
 
       .mobile-nav summary:focus-visible {
-        outline: 2px solid rgba(76, 207, 197, 0.35);
+        outline: 2px solid rgba(0, 214, 201, 0.35);
         outline-offset: 3px;
       }
 
@@ -215,8 +215,8 @@
 
       .mobile-nav-panel a:hover,
       .mobile-nav-panel a:focus-visible {
-        background: rgba(191, 244, 239, 0.5);
-        outline: 2px solid rgba(76, 207, 197, 0.25);
+        background: rgba(191, 247, 239, 0.5);
+        outline: 2px solid rgba(0, 214, 201, 0.25);
         outline-offset: 2px;
       }
 
@@ -239,7 +239,7 @@
       }
 
       .button.primary {
-        background: linear-gradient(135deg, var(--brand-deep), #41c1bc);
+        background: linear-gradient(135deg, var(--brand-deep), var(--brand));
         color: #fff;
       }
 
@@ -291,7 +291,7 @@
         font-weight: 800;
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        background: rgba(76, 207, 197, 0.16);
+        background: rgba(0, 214, 201, 0.16);
         color: var(--brand-deep);
       }
 
@@ -307,7 +307,7 @@
         line-height: 1;
         letter-spacing: 0;
         max-width: 13ch;
-        background: linear-gradient(120deg, #142e35 0%, #0a6570 58%, #d6944b 115%);
+        background: linear-gradient(120deg, #11333b 0%, #007985 55%, #00cfc2 112%);
         -webkit-background-clip: text;
         background-clip: text;
         color: transparent;
@@ -344,7 +344,7 @@
         color: var(--ink);
         font-size: 0.86rem;
         font-weight: 700;
-        box-shadow: 0 10px 24px rgba(24, 71, 79, 0.06);
+        box-shadow: 0 10px 24px rgba(0, 105, 118, 0.06);
       }
 
       .metric-row {
@@ -401,8 +401,8 @@
         position: relative;
         overflow: hidden;
         background:
-          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(230, 250, 247, 0.78)),
-          radial-gradient(circle at 92% 8%, rgba(242, 179, 109, 0.2), transparent 11rem);
+          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(222, 253, 248, 0.82)),
+          radial-gradient(circle at 92% 8%, rgba(0, 214, 201, 0.18), transparent 11rem);
         border-color: rgba(255, 255, 255, 0.9);
         box-shadow: var(--shadow-strong);
       }
@@ -465,13 +465,13 @@
         gap: 0.95rem;
         align-items: start;
         padding: 0.9rem;
-        border: 1px solid rgba(22, 51, 58, 0.07);
+        border: 1px solid rgba(17, 51, 59, 0.07);
         border-radius: 1rem;
         background: rgba(255, 255, 255, 0.62);
       }
 
       .delivery-item:first-child {
-        border-top: 1px solid rgba(22, 51, 58, 0.07);
+        border-top: 1px solid rgba(17, 51, 59, 0.07);
       }
 
       .delivery-item .delivery-code {
@@ -480,7 +480,7 @@
         width: 2.2rem;
         height: 2.2rem;
         border-radius: 0.75rem;
-        background: linear-gradient(145deg, rgba(24, 191, 192, 0.18), rgba(242, 179, 109, 0.18));
+        background: linear-gradient(145deg, rgba(0, 214, 201, 0.18), rgba(0, 121, 133, 0.12));
         color: var(--brand-deep);
         font-size: 0.78rem;
         font-weight: 800;
@@ -503,7 +503,7 @@
         padding: 0.6rem 0.85rem;
         border-radius: 0.7rem;
         font-size: 0.88rem;
-        background: rgba(22, 51, 58, 0.05);
+        background: rgba(17, 51, 59, 0.06);
       }
 
       .section-head {
@@ -558,8 +558,8 @@
       .stream-tab:focus-visible,
       .stream-tab[aria-selected="true"] {
         transform: translateX(4px);
-        border-color: rgba(76, 207, 197, 0.42);
-        background: rgba(191, 244, 239, 0.5);
+        border-color: rgba(0, 214, 201, 0.42);
+        background: rgba(191, 247, 239, 0.5);
       }
 
       .stream-tab strong {
@@ -600,7 +600,7 @@
       .stream-badge {
         padding: 0.45rem 0.7rem;
         border-radius: 0.7rem;
-        background: rgba(76, 207, 197, 0.13);
+        background: rgba(0, 214, 201, 0.13);
         color: var(--brand-deep);
         white-space: nowrap;
         font-size: 0.82rem;
@@ -629,8 +629,8 @@
       .quote-card {
         padding: 1rem;
         border-radius: 0.8rem;
-        background: rgba(22, 51, 58, 0.04);
-        border: 1px solid rgba(22, 51, 58, 0.06);
+        background: rgba(17, 51, 59, 0.04);
+        border: 1px solid rgba(17, 51, 59, 0.06);
       }
 
       .sub-item strong,
@@ -742,9 +742,9 @@
 
       .field input:focus-visible,
       .field textarea:focus-visible {
-        outline: 2px solid rgba(76, 207, 197, 0.25);
+        outline: 2px solid rgba(0, 214, 201, 0.25);
         outline-offset: 1px;
-        border-color: rgba(76, 207, 197, 0.46);
+        border-color: rgba(0, 214, 201, 0.46);
       }
 
       .form-meta {


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Current update:
- refresh the visual direction with a sea-glass palette, warm coral accent, and softer page atmosphere
- refine the Vindem Labs logo and favicon toward the earlier fluid mark, with a polished visible sunset-gradient underline beneath `VL`
- restore the simpler protected delivery note treatment for "Built around outcomes, usability, and long-term maintainability."
- tighten section spacing and delivery-card layout for a cleaner page rhythm
- update the social preview card to match the current brand direction