### PR TITLE
Rolling UX updates

### DIFF
--- a/.local-automation/merge_open_prs.sh
+++ b/.local-automation/merge_open_prs.sh
@@ -11,7 +11,7 @@ fi
 
 gh auth status >/dev/null
 
-prs_json="$(gh pr list --state open --json number,headRefName,baseRefName,url,mergeStateStatus --limit 100)"
+prs_json="$(gh pr list --state open --json number --limit 100)"
 
 if [[ "$prs_json" == "[]" ]]; then
   echo "No open PRs to process."
@@ -29,19 +29,23 @@ while IFS=$'\t' read -r pr_number head_branch base_branch pr_url merge_state; do
       [[ -z "$issue_number" ]] && continue
       gh issue close "$issue_number" --comment "Completed in merged PR #${pr_number}: ${pr_url}" >/dev/null 2>&1 || true
     done <<< "$issue_numbers"
+
+    if [[ "$head_branch" == "ux-only" && "$base_branch" == "main" ]]; then
+      git fetch origin main
+      if [[ "$(git branch --show-current)" == "ux-only" ]]; then
+        git reset --hard origin/main
+        git push origin HEAD:ux-only --force-with-lease
+      else
+        echo "Merged ux-only PR #${pr_number}; reset local ux-only before the next polish run."
+      fi
+    fi
   else
     echo "Skipping PR #${pr_number} with merge state ${merge_state}"
   fi
 done < <(
-  echo "$prs_json" | python3 - <<'PY'
-import json,sys
-for pr in json.load(sys.stdin):
-    print("\t".join([
-        str(pr.get("number","")),
-        pr.get("headRefName",""),
-        pr.get("baseRefName",""),
-        pr.get("url",""),
-        pr.get("mergeStateStatus",""),
-    ]))
-PY
+  gh pr list \
+    --state open \
+    --json number,headRefName,baseRefName,url,mergeStateStatus \
+    --limit 100 \
+    --jq '.[] | [.number, .headRefName, .baseRefName, .url, .mergeStateStatus] | @tsv'
 )

--- a/.local-automation/run_ux_polish.sh
+++ b/.local-automation/run_ux_polish.sh
@@ -49,6 +49,44 @@ ensure_pull_request() {
   done
 }
 
+close_tracking_issues_for_pr() {
+  local pr_number="$1"
+  local pr_url="$2"
+
+  local issue_numbers
+  issue_numbers="$(gh issue list --state open --json number,body --limit 100 --jq '.[] | select((.body // "") | contains("PR #'"$pr_number"'")) | .number' 2>/dev/null || true)"
+
+  while IFS= read -r issue_number; do
+    [[ -z "$issue_number" ]] && continue
+    gh issue close "$issue_number" --comment "Completed in merged PR #${pr_number}: ${pr_url}" >/dev/null 2>&1 || true
+  done <<< "$issue_numbers"
+}
+
+tidy_completed_workflow() {
+  while IFS=$'\t' read -r pr_number pr_url; do
+    [[ -z "$pr_number" ]] && continue
+    close_tracking_issues_for_pr "$pr_number" "$pr_url"
+  done < <(
+    gh pr list \
+      --head ux-only \
+      --base main \
+      --state closed \
+      --json number,url,mergedAt \
+      --jq '.[] | select(.mergedAt != null) | [.number, .url] | @tsv' 2>/dev/null || true
+  )
+}
+
+sync_ux_branch() {
+  git fetch --all --prune
+  git reset --hard origin/ux-only
+  git rebase origin/main
+
+  if [[ -z "$(git cherry origin/main HEAD)" ]]; then
+    git reset --hard origin/main
+    git push origin HEAD:ux-only --force-with-lease
+  fi
+}
+
 ensure_tracking_issue() {
   local commit_subject="$1"
 
@@ -102,9 +140,8 @@ main() {
   fi
 
   require_gh
-  git fetch --all --prune
-  git reset --hard origin/ux-only
-  git rebase origin/main
+  tidy_completed_workflow
+  sync_ux_branch
 
   "$CODEX_BIN" exec \
     --full-auto \
@@ -115,6 +152,11 @@ main() {
     - < "$PROMPT_FILE"
 
   git fetch origin ux-only
+
+  if [[ -z "$(git cherry origin/main origin/ux-only)" ]]; then
+    echo "No ux-only changes to publish."
+    exit 0
+  fi
 
   local remote_sha commit_subject
   remote_sha="$(git rev-parse origin/ux-only)"

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vindem Labs">
   <defs>
     <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
-      <stop offset="0%" stop-color="#fff6e8" />
-      <stop offset="55%" stop-color="#d7f8f0" />
-      <stop offset="100%" stop-color="#6ddbd5" />
+      <stop offset="0%" stop-color="#fff7e9" />
+      <stop offset="55%" stop-color="#d8fbf5" />
+      <stop offset="100%" stop-color="#70ded8" />
     </linearGradient>
     <linearGradient id="ink" x1="16%" y1="12%" x2="84%" y2="88%">
       <stop offset="0%" stop-color="#00a7b3" />
@@ -14,18 +14,17 @@
       <stop offset="42%" stop-color="#ff9f4a" />
       <stop offset="100%" stop-color="#d95f52" />
     </linearGradient>
-    <filter id="accent-lift" x="-20%" y="-120%" width="140%" height="340%">
-      <feDropShadow dx="0" dy="1.2" stdDeviation="0.9" flood-color="#d95f52" flood-opacity="0.24" />
-    </filter>
-    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
-      <feDropShadow dx="0" dy="3" stdDeviation="2.3" flood-color="#07545d" flood-opacity="0.2" />
-    </filter>
   </defs>
   <rect x="3" y="3" width="58" height="58" rx="18" fill="url(#tile)" />
   <path d="M10 18C20 9 35 9 47 17C55 22 59 31 56 42C53 53 44 58 32 57C20 56 10 49 8 37C7 29 6 23 10 18Z" fill="#ffffff" opacity="0.65" />
-  <g filter="url(#lift)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
+  <g fill="none" stroke="#07545d" stroke-linecap="round" stroke-linejoin="round" opacity="0.16">
+    <path d="M15.2 18.2L29.4 48.7L41.8 18.2" stroke-width="7" />
+    <path d="M44.8 18.2V45.6C44.8 48.2 46.8 50.2 49.4 50.2H55" stroke-width="7" />
+  </g>
+  <g fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
     <path d="M14.2 17L28.4 47.5L40.8 17" stroke-width="6.6" />
     <path d="M43.8 17V44.4C43.8 47 45.8 49 48.4 49H54" stroke-width="6.6" />
   </g>
-  <rect x="18" y="50.2" width="33" height="5.2" rx="2.6" fill="url(#sunset)" filter="url(#accent-lift)" />
+  <rect x="18" y="50.2" width="33" height="5.2" rx="2.6" fill="#d95f52" opacity="0.16" />
+  <rect x="18" y="49.6" width="33" height="5.2" rx="2.6" fill="url(#sunset)" />
 </svg>

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -9,11 +9,14 @@
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <linearGradient id="sunset" x1="17" y1="50" x2="51" y2="55" gradientUnits="userSpaceOnUse">
+    <linearGradient id="sunset" x1="18" y1="50" x2="52" y2="55" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#ffd26f" />
       <stop offset="42%" stop-color="#ff9f4a" />
       <stop offset="100%" stop-color="#d95f52" />
     </linearGradient>
+    <filter id="accent-lift" x="-20%" y="-120%" width="140%" height="340%">
+      <feDropShadow dx="0" dy="1.2" stdDeviation="0.9" flood-color="#d95f52" flood-opacity="0.24" />
+    </filter>
     <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
       <feDropShadow dx="0" dy="3" stdDeviation="2.3" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
@@ -24,5 +27,5 @@
     <path d="M14.2 17L28.4 47.5L40.8 17" stroke-width="6.6" />
     <path d="M43.8 17V44.4C43.8 47 45.8 49 48.4 49H54" stroke-width="6.6" />
   </g>
-  <rect x="17" y="50" width="34" height="5.8" rx="2.9" fill="url(#sunset)" />
+  <rect x="18" y="50.2" width="33" height="5.2" rx="2.6" fill="url(#sunset)" filter="url(#accent-lift)" />
 </svg>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -14,11 +14,14 @@
       <stop offset="0%" stop-color="#00a7b3" />
       <stop offset="100%" stop-color="#11343b" />
     </linearGradient>
-    <linearGradient id="sunset" x1="116" y1="184" x2="204" y2="194" gradientUnits="userSpaceOnUse">
+    <linearGradient id="sunset" x1="118" y1="184" x2="204" y2="194" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#ffd26f" />
       <stop offset="42%" stop-color="#ff9f4a" />
       <stop offset="100%" stop-color="#d95f52" />
     </linearGradient>
+    <filter id="accent-lift" x="-20%" y="-120%" width="140%" height="340%">
+      <feDropShadow dx="0" dy="3" stdDeviation="2.2" flood-color="#d95f52" flood-opacity="0.24" />
+    </filter>
     <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
       <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
     </filter>
@@ -36,7 +39,7 @@
     <path d="M110 108L141 175L168 108" stroke-width="14" />
     <path d="M175 108V162C175 171 181 177 190 177H203" stroke-width="14" />
   </g>
-  <rect x="116" y="184" width="88" height="12" rx="6" fill="url(#sunset)" />
+  <rect x="118" y="184" width="86" height="11" rx="5.5" fill="url(#sunset)" filter="url(#accent-lift)" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/assets/og-card.svg
+++ b/assets/og-card.svg
@@ -2,13 +2,13 @@
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#fffefd" />
-      <stop offset="47%" stop-color="#f5fbf8" />
-      <stop offset="100%" stop-color="#d9f4f1" />
+      <stop offset="47%" stop-color="#f4fdf9" />
+      <stop offset="100%" stop-color="#d8fbf5" />
     </linearGradient>
     <linearGradient id="tile" x1="8%" y1="6%" x2="92%" y2="94%">
-      <stop offset="0%" stop-color="#fff6e8" />
-      <stop offset="55%" stop-color="#d7f8f0" />
-      <stop offset="100%" stop-color="#6ddbd5" />
+      <stop offset="0%" stop-color="#fff7e9" />
+      <stop offset="55%" stop-color="#d8fbf5" />
+      <stop offset="100%" stop-color="#70ded8" />
     </linearGradient>
     <linearGradient id="ink" x1="16%" y1="12%" x2="84%" y2="88%">
       <stop offset="0%" stop-color="#00a7b3" />
@@ -19,27 +19,26 @@
       <stop offset="42%" stop-color="#ff9f4a" />
       <stop offset="100%" stop-color="#d95f52" />
     </linearGradient>
-    <filter id="accent-lift" x="-20%" y="-120%" width="140%" height="340%">
-      <feDropShadow dx="0" dy="3" stdDeviation="2.2" flood-color="#d95f52" flood-opacity="0.24" />
-    </filter>
-    <filter id="lift" x="-16%" y="-16%" width="132%" height="132%">
-      <feDropShadow dx="0" dy="8" stdDeviation="7" flood-color="#07545d" flood-opacity="0.2" />
-    </filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)" />
-  <circle cx="1018" cy="108" r="190" fill="#beece7" opacity="0.68" />
-  <circle cx="1058" cy="145" r="86" fill="#f4976c" opacity="0.2" />
+  <circle cx="1018" cy="108" r="190" fill="#b7f2ea" opacity="0.72" />
+  <circle cx="1058" cy="145" r="86" fill="#ff9861" opacity="0.24" />
   <path d="M0 505C144 468 292 493 428 546C546 592 662 588 780 535C900 481 1036 472 1200 518V630H0Z" fill="#62d4d0" opacity="0.24" />
   <path d="M762 0H1200V630H888C792 508 754 364 779 212C793 128 805 60 762 0Z" fill="#fff2dc" opacity="0.66" />
   <path d="M970 390C1016 348 1084 348 1138 390" fill="none" stroke="#00a7b3" stroke-width="22" stroke-linecap="round" opacity="0.18" />
 
   <rect x="86" y="78" width="124" height="124" rx="38" fill="url(#tile)" />
-  <path d="M101 111C118 91 153 89 180 106C199 119 206 143 195 165C184 188 156 199 127 189C104 181 90 159 92 135C93 125 94 117 101 111Z" fill="#ffffff" opacity="0.64" />
-  <g filter="url(#lift)" fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M101 111C118 91 153 89 180 106C199 119 206 143 195 165C184 188 156 199 127 189C104 181 90 159 92 135C93 125 94 117 101 111Z" fill="#ffffff" opacity="0.66" />
+  <g fill="none" stroke="#07545d" stroke-linecap="round" stroke-linejoin="round" opacity="0.16">
+    <path d="M112 110L143 177L170 110" stroke-width="15" />
+    <path d="M177 110V164C177 173 183 179 192 179H205" stroke-width="15" />
+  </g>
+  <g fill="none" stroke="url(#ink)" stroke-linecap="round" stroke-linejoin="round">
     <path d="M110 108L141 175L168 108" stroke-width="14" />
     <path d="M175 108V162C175 171 181 177 190 177H203" stroke-width="14" />
   </g>
-  <rect x="118" y="184" width="86" height="11" rx="5.5" fill="url(#sunset)" filter="url(#accent-lift)" />
+  <rect x="118" y="186" width="86" height="11" rx="5.5" fill="#d95f52" opacity="0.16" />
+  <rect x="118" y="184" width="86" height="11" rx="5.5" fill="url(#sunset)" />
 
   <text x="86" y="302" fill="#133138" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="78" font-weight="800">Vindem Labs</text>
   <text x="86" y="374" fill="#55747b" font-family="Sora, Avenir Next, Segoe UI, sans-serif" font-size="31">Web, mobile, software, and connected digital platforms.</text>

--- a/index.html
+++ b/index.html
@@ -8,20 +8,20 @@
       name="description"
       content="Vindem Labs designs and builds consumer apps, enterprise software, websites, and digital platforms across PropTech, AI education, property operations, and IoT."
     />
-    <meta name="theme-color" content="#d9f4f1" />
+    <meta name="theme-color" content="#d8fbf5" />
     <meta property="og:title" content="Vindem Labs" />
     <meta
       property="og:description"
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=9" />
+    <meta property="og:image" content="assets/og-card.svg?v=10" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=9" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <style>
       :root {
-        --bg: #f5fbf8;
-        --bg-deep: #d9f4f1;
+        --bg: #f4fdf9;
+        --bg-deep: #d8fbf5;
         --panel: rgba(255, 255, 255, 0.8);
         --panel-strong: rgba(255, 255, 255, 0.96);
         --text: #133138;
@@ -29,13 +29,13 @@
         --line: rgba(19, 49, 56, 0.1);
         --brand: #00a7b3;
         --brand-deep: #07545d;
-        --brand-soft: #beece7;
-        --accent: #f4976c;
+        --brand-soft: #b7f2ea;
+        --accent: #ff9861;
         --ink: #213e44;
-        --cream: #fff2dc;
-        --mint: #dff8ef;
-        --shadow: 0 18px 42px rgba(7, 84, 93, 0.1);
-        --shadow-strong: 0 28px 70px rgba(7, 84, 93, 0.16);
+        --cream: #fff3dd;
+        --mint: #ddfbf0;
+        --shadow: 0 18px 42px rgba(7, 84, 93, 0.085);
+        --shadow-strong: 0 28px 70px rgba(7, 84, 93, 0.14);
         --radius: 22px;
         --max: 1180px;
       }
@@ -54,10 +54,10 @@
         color: var(--text);
         overflow-x: hidden;
         background:
-          radial-gradient(circle at 7% 10%, rgba(255, 242, 220, 0.9), transparent 25rem),
-          radial-gradient(circle at 88% 8%, rgba(0, 167, 179, 0.18), transparent 25rem),
-          radial-gradient(circle at 18% 92%, rgba(244, 151, 108, 0.14), transparent 28rem),
-          linear-gradient(180deg, #fffefd 0%, var(--bg) 46%, var(--bg-deep) 100%);
+          radial-gradient(circle at 7% 10%, rgba(255, 243, 221, 0.98), transparent 25rem),
+          radial-gradient(circle at 86% 8%, rgba(0, 188, 196, 0.23), transparent 25rem),
+          radial-gradient(circle at 18% 92%, rgba(255, 152, 97, 0.18), transparent 28rem),
+          linear-gradient(180deg, #fffefd 0%, var(--bg) 45%, var(--bg-deep) 100%);
       }
 
       body::before {
@@ -69,7 +69,7 @@
         transform: translateX(12%);
         border-radius: 38% 62% 44% 56%;
         background:
-          linear-gradient(135deg, rgba(0, 167, 179, 0.18), rgba(244, 151, 108, 0.16)),
+          linear-gradient(135deg, rgba(0, 188, 196, 0.2), rgba(255, 152, 97, 0.18)),
           radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.88), transparent 34%);
         filter: blur(2px);
         opacity: 0.72;
@@ -104,7 +104,7 @@
         top: 0;
         z-index: 20;
         backdrop-filter: blur(18px);
-        background: rgba(245, 251, 248, 0.82);
+        background: rgba(247, 253, 250, 0.84);
         border-bottom: 1px solid rgba(19, 49, 56, 0.06);
       }
 
@@ -912,7 +912,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=9" alt="" />
+            <img src="assets/favicon.svg?v=10" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs

--- a/index.html
+++ b/index.html
@@ -15,9 +15,9 @@
       content="Vindem Labs creates digital products, software platforms, and connected web experiences for modern businesses."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="assets/og-card.svg?v=8" />
+    <meta property="og:image" content="assets/og-card.svg?v=9" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
-    <link rel="icon" href="assets/favicon.svg?v=8" type="image/svg+xml" />
+    <link rel="icon" href="assets/favicon.svg?v=9" type="image/svg+xml" />
     <style>
       :root {
         --bg: #f5fbf8;
@@ -912,7 +912,7 @@
       <div class="shell">
         <a class="brand" href="#top" aria-label="Vindem Labs home">
           <span class="brand-mark" aria-hidden="true">
-            <img src="assets/favicon.svg?v=8" alt="" />
+            <img src="assets/favicon.svg?v=9" alt="" />
           </span>
           <span class="brand-copy">
             Vindem Labs


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #10

Current update:
- brighten the sea-glass theme slightly with more luminous aqua and warm highlights
- remove SVG filter-based shadows from the logo assets to avoid visible square overlay artifacts
- polish the Vindem Labs favicon and social preview underline so the sunset accent stays integrated and visible
- harden Mr V's git workflow so merged or closed ux-only PRs/issues are tidied before future automation runs
- keep the protected delivery note unchanged: "Built around outcomes, usability, and long-term maintainability."

test: HTML/SVG parse checks, shell syntax checks for workflow scripts, `gh pr list --jq` TSV smoke check, and local browser preview at `?brand=bright-v10#top`