### PR TITLE
Rolling UX updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,10 +16,8 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="assets/og-card.svg?v=10" />
-    <meta property="og:url" content="https://v-labs-core.github.io" />
-    <meta name="privacy-policy" content="https://v-labs-core.github.io/privacy.html" />
-    <link rel="canonical" href="https://v-labs-core.github.io/" />
-    <link rel="privacy-policy" href="https://v-labs-core.github.io/privacy.html" />
+    <meta name="privacy-policy" content="privacy.html" />
+    <link rel="privacy-policy" href="privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <style>
       :root {

--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:image" content="assets/og-card.svg?v=10" />
     <meta property="og:url" content="https://v-labs-core.github.io" />
+    <meta name="privacy-policy" content="https://v-labs-core.github.io/privacy.html" />
+    <link rel="canonical" href="https://v-labs-core.github.io/" />
+    <link rel="privacy-policy" href="https://v-labs-core.github.io/privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <style>
       :root {
@@ -945,7 +948,7 @@
           <a href="#focus">Sectors</a>
           <a href="#engine">Approach</a>
           <a href="#roadmap">Roadmap</a>
-          <a href="#privacy-policy">Privacy</a>
+          <a href="privacy.html">Privacy</a>
           <a class="button secondary" href="#contact">Contact</a>
         </nav>
 
@@ -956,7 +959,7 @@
             <a href="#focus">Sectors</a>
             <a href="#engine">Approach</a>
             <a href="#roadmap">Roadmap</a>
-            <a href="#privacy-policy">Privacy</a>
+            <a href="privacy.html">Privacy</a>
             <a href="#contact">Contact</a>
           </div>
         </details>
@@ -1535,7 +1538,8 @@
                   Vindem Labs LLC does not share, sell, or rent your mobile phone number or any
                   personal information collected through SMS messaging with third parties for their
                   marketing purposes. Your mobile number will only be used to send you the SMS
-                  messages you have opted in to receive.
+                  messages you have opted in to receive. <a href="privacy.html">Read the full
+                  privacy policy.</a>
                 </p>
               </div>
             </form>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy | Vindem Labs LLC</title>
+    <meta
+      name="description"
+      content="Vindem Labs LLC privacy policy for SMS messaging and mobile phone number handling."
+    />
+    <meta name="robots" content="index, follow" />
+    <meta name="theme-color" content="#d8fbf5" />
+    <meta property="og:title" content="Privacy Policy | Vindem Labs LLC" />
+    <meta
+      property="og:description"
+      content="Vindem Labs LLC does not share, sell, or rent mobile phone numbers or SMS messaging personal information with third parties for marketing purposes."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://v-labs-core.github.io/privacy.html" />
+    <meta property="og:image" content="assets/og-card.svg?v=10" />
+    <link rel="canonical" href="https://v-labs-core.github.io/privacy.html" />
+    <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "PrivacyPolicy",
+        "name": "Privacy Policy",
+        "url": "https://v-labs-core.github.io/privacy.html",
+        "publisher": {
+          "@type": "Organization",
+          "name": "Vindem Labs LLC"
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --bg: #f4fdf9;
+        --bg-deep: #d8fbf5;
+        --text: #133138;
+        --muted: #55747b;
+        --line: rgba(19, 49, 56, 0.1);
+        --brand: #00a7b3;
+        --brand-deep: #07545d;
+        --accent: #ff9861;
+        --shadow: 0 24px 64px rgba(7, 84, 93, 0.12);
+        --max: 860px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Sora", "Avenir Next", "Segoe UI", sans-serif;
+        color: var(--text);
+        background:
+          radial-gradient(circle at 9% 10%, rgba(255, 243, 221, 0.98), transparent 24rem),
+          radial-gradient(circle at 88% 12%, rgba(0, 188, 196, 0.2), transparent 24rem),
+          linear-gradient(180deg, #fffefd 0%, var(--bg) 48%, var(--bg-deep) 100%);
+        min-height: 100vh;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .shell {
+        width: min(calc(100% - 2rem), var(--max));
+        margin: 0 auto;
+      }
+
+      header {
+        padding: 1.2rem 0;
+      }
+
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.8rem;
+        color: var(--text);
+        font-weight: 800;
+        text-decoration: none;
+      }
+
+      .brand img {
+        width: 2.5rem;
+        height: 2.5rem;
+        border-radius: 0.85rem;
+        box-shadow: 0 8px 22px rgba(7, 84, 93, 0.16);
+      }
+
+      main {
+        padding: 3.5rem 0 5rem;
+      }
+
+      .policy-card {
+        padding: clamp(1.35rem, 4vw, 2.4rem);
+        border: 1px solid rgba(255, 255, 255, 0.82);
+        border-radius: 1.6rem;
+        background:
+          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(221, 251, 240, 0.82)),
+          radial-gradient(circle at 92% 8%, rgba(255, 152, 97, 0.16), transparent 12rem);
+        box-shadow: var(--shadow);
+      }
+
+      .kicker {
+        margin: 0 0 0.65rem;
+        color: var(--brand-deep);
+        font-size: 0.82rem;
+        font-weight: 800;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2.3rem, 7vw, 4.4rem);
+        line-height: 1;
+        letter-spacing: -0.03em;
+      }
+
+      .policy-text {
+        margin: 1.3rem 0 0;
+        color: var(--muted);
+        font-size: 1.05rem;
+        line-height: 1.75;
+      }
+
+      .back-link {
+        display: inline-flex;
+        margin-top: 1.6rem;
+        padding: 0.85rem 1rem;
+        border-radius: 0.8rem;
+        background: linear-gradient(135deg, var(--brand-deep), var(--brand));
+        color: #fff;
+        font-weight: 800;
+        text-decoration: none;
+      }
+
+      footer {
+        padding: 0 0 2rem;
+        color: var(--muted);
+        font-size: 0.92rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="shell">
+        <a class="brand" href="index.html" aria-label="Vindem Labs home">
+          <img src="assets/favicon.svg?v=10" alt="" />
+          <span>Vindem Labs LLC</span>
+        </a>
+      </div>
+    </header>
+
+    <main>
+      <div class="shell">
+        <article class="policy-card" aria-labelledby="privacy-title">
+          <p class="kicker">Privacy policy</p>
+          <h1 id="privacy-title">Privacy Policy</h1>
+          <p class="policy-text">
+            Vindem Labs LLC does not share, sell, or rent your mobile phone number or any personal
+            information collected through SMS messaging with third parties for their marketing
+            purposes. Your mobile number will only be used to send you the SMS messages you have
+            opted in to receive.
+          </p>
+          <a class="back-link" href="index.html#contact">Return to contact</a>
+        </article>
+      </div>
+    </main>
+
+    <footer>
+      <div class="shell">Vindem Labs LLC</div>
+    </footer>
+  </body>
+</html>

--- a/privacy.html
+++ b/privacy.html
@@ -16,16 +16,14 @@
       content="Vindem Labs LLC does not share, sell, or rent mobile phone numbers or SMS messaging personal information with third parties for marketing purposes."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://v-labs-core.github.io/privacy.html" />
     <meta property="og:image" content="assets/og-card.svg?v=10" />
-    <link rel="canonical" href="https://v-labs-core.github.io/privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "PrivacyPolicy",
         "name": "Privacy Policy",
-        "url": "https://v-labs-core.github.io/privacy.html",
+        "url": "privacy.html",
         "publisher": {
           "@type": "Organization",
           "name": "Vindem Labs LLC"


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #16

Current update:
- add a dedicated crawler-friendly `privacy.html` page with the requested Vindem Labs LLC SMS/mobile privacy text
- point the header Privacy links to the standalone privacy page using relative URLs
- remove hardcoded GitHub Pages URLs from homepage/privacy metadata so the static site stays host-agnostic
- keep the contact-form privacy note and protected delivery note intact

test: HTML parse checks, URL scan for hardcoded hosting paths, and local browser/DOM check for the privacy page text