### PR TITLE
Rolling UX updates

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload public site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.local-automation/README.md
+++ b/.local-automation/README.md
@@ -13,5 +13,5 @@ Main scripts:
 - `merge_open_prs.sh`: merges mergeable open PRs and closes linked issues
 
 These scripts assume the folder is a real Git checkout of `v-labs-core/v-labs-core.github.io`.
-The hosted website lives in `docs/`; root-level automation files and repository notes are not
-part of the public web root.
+The hosted website lives in `docs/` and is deployed by the GitHub Pages workflow; root-level
+automation files and repository notes are not part of the public web artifact.

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Static GitHub Pages site for Vindem Labs.
 - `docs/.nojekyll`: tells GitHub Pages to serve files as-is
 - `.local-automation/`: local workflow scripts that are not part of the hosted site
 
-GitHub Pages should publish from the `main` branch and `/docs` folder so repo automation,
-README files, and workflow notes are not served as website assets.
+GitHub Pages deploys through `.github/workflows/pages.yml`, which uploads only the `docs/`
+folder. Repo automation, README files, and workflow notes are not included in the hosted
+artifact.
 
 ## Contact form
 


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #20

Current update:
- add a GitHub Actions Pages workflow that uploads only the `docs/` folder as the hosted artifact
- avoid the legacy Pages/Jekyll behavior that was rendering the root README despite the `/docs` source setting
- update repo workflow notes to describe the artifact-based Pages deployment

Tests:
- workflow file reviewed for official Pages action flow
- `git diff --check`
- live Pages verification showed legacy publishing was serving the root README, which this workflow replaces