### PR TITLE
Rolling UX updates

### DIFF
--- a/.github/workflows/sync-deploy-branch.yml
+++ b/.github/workflows/sync-deploy-branch.yml
@@ -1,0 +1,64 @@
+name: Sync Deploy Branch
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - .github/workflows/sync-deploy-branch.yml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-deploy-branch
+  cancel-in-progress: false
+
+env:
+  DEPLOY_BRANCH: deploy
+  PUBLIC_ROOT: docs
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          path: source
+
+      - name: Prepare deploy branch workspace
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$RUNNER_TEMP/deploy-worktree"
+          cd "$RUNNER_TEMP/deploy-worktree"
+
+          git init
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --depth=1 origin "${DEPLOY_BRANCH}" || true
+
+          if git show-ref --verify --quiet "refs/remotes/origin/${DEPLOY_BRANCH}"; then
+            git checkout -B "${DEPLOY_BRANCH}" "origin/${DEPLOY_BRANCH}"
+          else
+            git checkout --orphan "${DEPLOY_BRANCH}"
+          fi
+
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          rsync -a --delete "$GITHUB_WORKSPACE/source/${PUBLIC_ROOT}/" ./
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "Deploy branch already matches ${PUBLIC_ROOT}/."
+            exit 0
+          fi
+
+          git commit -m "Sync deploy branch from ${PUBLIC_ROOT}"
+          git push origin "${DEPLOY_BRANCH}" --force-with-lease
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.local-automation/README.md
+++ b/.local-automation/README.md
@@ -15,3 +15,4 @@ Main scripts:
 These scripts assume the folder is a real Git checkout of `v-labs-core/v-labs-core.github.io`.
 The hosted website lives in `docs/` and is deployed by the GitHub Pages workflow; root-level
 automation files and repository notes are not part of the public web artifact.
+The `deploy` branch is an automation-managed mirror of `docs/` contents only.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ GitHub Pages deploys through `.github/workflows/pages.yml`, which uploads only t
 folder. Repo automation, README files, and workflow notes are not included in the hosted
 artifact.
 
+`.github/workflows/sync-deploy-branch.yml` also mirrors only the contents of `docs/` to the
+dedicated `deploy` branch. That branch is a clean deploy artifact branch and should not contain
+repo automation, README files, or source-only workflow notes.
+
 ## Contact form
 
 The contact form is designed for a static hosting setup and does not display a public email


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #22

Current update:
- add a `Sync Deploy Branch` GitHub Action that mirrors only `docs/` contents to the dedicated `deploy` branch
- keep the deploy branch free of repository README, automation scripts, workflow notes, and source-only files
- document the `deploy` branch as an automation-managed deploy artifact branch

Tests:
- reviewed workflow script for docs-only sync behavior
- `git diff --check`