### PR TITLE
Rolling UX updates

### DIFF
--- a/.local-automation/README.md
+++ b/.local-automation/README.md
@@ -11,8 +11,18 @@ Expected repo setup:
 Main scripts:
 - `run_ux_polish.sh`: runs a bounded Codex UX pass, then syncs the rolling PR and tracking issue
 - `merge_open_prs.sh`: merges mergeable open PRs and closes linked issues
+- `launchd-v-labs-core-ux-polish.template.plist`: documents the local fallback scheduler
 
 These scripts assume the folder is a real Git checkout of `v-labs-core/v-labs-core.github.io`.
 The hosted website lives in `docs/` and is deployed by the GitHub Pages workflow; root-level
 automation files and repository notes are not part of the public web artifact.
 The `deploy` branch is an automation-managed mirror of `docs/` contents only.
+
+Local fallback scheduler:
+- live plist: `/Users/mrv/Library/LaunchAgents/com.mrv.v-labs-core-ux-polish.plist`
+- label: `com.mrv.v-labs-core-ux-polish`
+- interval: `21600` seconds
+- run at load: enabled
+
+The fallback scheduler and the Codex cron automation both run `run_ux_polish.sh`; the script
+remains the single source of truth for branch, PR, issue, and label handling.

--- a/.local-automation/launchd-v-labs-core-ux-polish.template.plist
+++ b/.local-automation/launchd-v-labs-core-ux-polish.template.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.mrv.v-labs-core-ux-polish</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>/Users/mrv/workspace/v-labs-core.github.io/.local-automation/run_ux_polish.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/mrv/workspace/v-labs-core.github.io</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StartInterval</key>
+  <integer>21600</integer>
+
+  <key>StandardOutPath</key>
+  <string>/Users/mrv/workspace/v-labs-core.github.io/.local-automation/launchd.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/mrv/workspace/v-labs-core.github.io/.local-automation/launchd.stderr.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #28

Current update:
- add the missing V Labs `launchd` fallback automation template
- document the live LaunchAgent path, label, cadence, and shared `run_ux_polish.sh` entrypoint
- align the V Labs automation setup with the notifications project fallback layer

Tests:
- `plutil -lint` on the live plist and repo template
- `git diff --check`