### PR TITLE
Rolling UX updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.local-automation/*.log
+.local-automation/last_run_summary.txt


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #30

Current update:
- ignore local automation runtime files so `launchd` stdout/stderr logs do not dirty the worktree
- keep `last_run_summary.txt` local-only
- unblock the V Labs launchd fallback from failing its clean-tree preflight on startup

Tests:
- `git diff --check`
- inspected launchd stdout showing clean-tree preflight was the startup blocker