### PR TITLE
Rolling UX updates

### DIFF
--- a/.local-automation/launchd-v-labs-core-ux-polish.template.plist
+++ b/.local-automation/launchd-v-labs-core-ux-polish.template.plist
@@ -14,6 +14,12 @@
   <key>WorkingDirectory</key>
   <string>/Users/mrv/workspace/v-labs-core.github.io</string>
 
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/Users/mrv/.nvm/versions/node/v24.12.0/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+
   <key>RunAtLoad</key>
   <true/>
 


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #32

Current update:
- set an explicit launchd `PATH` for the V Labs fallback automation
- include Homebrew and Codex CLI paths so launchd can find `gh` and the automation tooling
- keep the live LaunchAgent template aligned with the installed fallback scheduler

Tests:
- `plutil -lint` on the live plist and repo template
- `git diff --check`
- inspected launchd default environment showing `/opt/homebrew/bin` was missing