### PR TITLE
Rolling UX updates

### DIFF
--- a/.local-automation/launchd-v-labs-core-ux-polish.template.plist
+++ b/.local-automation/launchd-v-labs-core-ux-polish.template.plist
@@ -7,7 +7,7 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/bin/zsh</string>
+    <string>/bin/bash</string>
     <string>/Users/mrv/workspace/v-labs-core.github.io/.local-automation/run_ux_polish.sh</string>
   </array>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -909,6 +909,49 @@
           font-size: 2rem;
         }
 
+        .stream-tabs {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.55rem;
+        }
+
+        .stream-tab {
+          min-height: 4.25rem;
+          padding: 0.85rem 0.75rem;
+          text-align: center;
+          border-radius: 0.9rem;
+          display: grid;
+          place-items: center;
+        }
+
+        .stream-tab:hover,
+        .stream-tab:focus-visible,
+        .stream-tab[aria-selected="true"] {
+          transform: translateY(-2px);
+        }
+
+        .stream-tab strong {
+          margin-bottom: 0;
+          font-size: 0.9rem;
+          line-height: 1.25;
+        }
+
+        .stream-tab span {
+          display: none;
+        }
+
+        .stream-panel {
+          padding: 1.1rem;
+        }
+
+        .stream-header {
+          display: grid;
+        }
+
+        .stream-badge {
+          justify-self: start;
+          white-space: normal;
+        }
+
         .delivery-item {
           grid-template-columns: 1fr;
           gap: 0.25rem;


### PR DESCRIPTION
This PR tracks rolling UX-only improvements from the `ux-only` branch.

Tracking issue: #34

Current update:
- improve the mobile Offerings tab layout with a compact two-column segmented control
- preserve the protected homepage line
- update the V Labs launchd fallback template so it runs the Bash automation script with Bash

Tests:
- `git diff --check`
- launchd fallback reached `codex exec`, produced commit `0d5f081`, and pushed to `ux-only`
- PR cleanup completed manually after identifying the shell mismatch from the first fallback run