### PR TITLE
Make deploy branch pull-friendly

### DIFF
--- a/.github/workflows/sync-deploy-branch.yml
+++ b/.github/workflows/sync-deploy-branch.yml
@@ -33,5 +33,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: ${{ env.DEPLOY_BRANCH }}
           publish_dir: ./${{ env.PUBLIC_ROOT }}
-          force_orphan: true
           commit_message: Sync deploy branch from ${{ env.PUBLIC_ROOT }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ artifact.
 
 `.github/workflows/sync-deploy-branch.yml` also mirrors only the contents of `docs/` to the
 dedicated `deploy` branch. That branch is a clean deploy artifact branch and should not contain
-repo automation, README files, or source-only workflow notes.
+repo automation, README files, or source-only workflow notes. The branch is updated with normal
+history so downstream hosts can pull it without reconciling force-rewritten commits.
 
 ## Contact form
 


### PR DESCRIPTION
This PR tracks the deploy workflow update from the `ux-only` branch.\n\nTracking issue: #37\n\nCurrent update:\n- remove forced orphan publishing from the deploy branch sync\n- keep the deploy branch history pull-friendly for downstream hosts like Hostinger\n- document that deploy branch history is intentionally normal instead of force-rewritten\n\nTests:\n- `git diff --check`\n- reviewed workflow diff