### PR TITLE
Make privacy page fully standalone

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>Vindem Labs | Web, Mobile, Software, and Digital Platforms</title>
     <meta
       name="description"
-      content="Vindem Labs LLC builds web, mobile, software, and digital platforms across PropTech, AI education, property operations, IoT, and publisher websites. View the SMS and mobile privacy policy on this page."
+      content="Vindem Labs LLC builds web, mobile, software, and digital platforms across PropTech, AI education, property operations, IoT, and publisher websites. View the SMS and mobile privacy policy at privacy.html."
     />
     <meta
       name="keywords"
@@ -20,7 +20,7 @@
     <meta property="og:title" content="Vindem Labs" />
     <meta
       property="og:description"
-      content="Vindem Labs LLC creates digital products, software platforms, websites, and connected web experiences. The SMS and mobile privacy policy is available on the homepage."
+      content="Vindem Labs LLC creates digital products, software platforms, websites, and connected web experiences. The SMS and mobile privacy policy is available at privacy.html."
     />
     <meta property="og:site_name" content="Vindem Labs" />
     <meta property="og:type" content="website" />
@@ -29,7 +29,7 @@
     <meta name="twitter:title" content="Vindem Labs" />
     <meta
       name="twitter:description"
-      content="Web, mobile, software, and digital platforms from Vindem Labs LLC, with the SMS and mobile privacy policy available on the homepage."
+      content="Web, mobile, software, and digital platforms from Vindem Labs LLC, with the SMS and mobile privacy policy available at privacy.html."
     />
     <meta name="privacy-policy" content="privacy.html" />
     <link rel="privacy-policy" href="privacy.html" />
@@ -1891,15 +1891,10 @@
                 </p>
               </div>
 
-              <section class="privacy-note" id="privacy-policy" aria-labelledby="privacy-title">
-                <h2 id="privacy-title">Privacy policy</h2>
-                <p>
-                  Vindem Labs LLC does not share, sell, or rent your mobile phone number or any
-                  personal information collected through SMS messaging with third parties for their
-                  marketing purposes. Your mobile number will only be used to send you the SMS
-                  messages you have opted in to receive.
-                </p>
-              </section>
+              <p class="privacy-note">
+                Review the standalone <a href="privacy.html">Vindem Labs privacy policy</a> for SMS
+                and mobile information handling terms.
+              </p>
             </form>
           </div>
         </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -97,7 +97,16 @@
 
       .back-link {
         display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 3rem;
         margin-top: 1.5rem;
+        padding: 0.85rem 1.15rem;
+        border-radius: 999px;
+        background: var(--brand);
+        color: #ffffff;
+        text-decoration: none;
+        box-shadow: 0 14px 32px rgba(7, 84, 93, 0.16);
       }
     </style>
   </head>
@@ -120,7 +129,7 @@
           </p>
         </section>
 
-        <a class="back-link" href="./">Return to Vindem Labs</a>
+        <a class="back-link" href="https://vindem.tech">Return to vindem.tech</a>
       </article>
     </main>
   </body>


### PR DESCRIPTION
This PR tracks a focused privacy-page update from the `ux-only` branch.\n\nTracking issue: #45\n\nCurrent update:\n- remove homepage/contact wording from homepage privacy metadata\n- replace the embedded contact-form privacy text with a link to `privacy.html`\n- keep `privacy.html` as the standalone crawler-readable policy page\n- add a button-style link from `privacy.html` back to `https://vindem.tech`\n\nIssue cleanup:\n- closed #44 as completed by merged PR #43\n\nTests:\n- HTML parse check for `docs/index.html` and `docs/privacy.html`\n- `git diff --check`\n- grep check for stale homepage/contact privacy redirect references