### PR TITLE
Fix privacy links and contact copy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,8 +31,8 @@
       name="twitter:description"
       content="Web, mobile, software, and digital platforms from Vindem Labs LLC, with the SMS and mobile privacy policy available at privacy.html."
     />
-    <meta name="privacy-policy" content="privacy.html" />
-    <link rel="privacy-policy" href="privacy.html" />
+    <meta name="privacy-policy" content="./privacy.html" />
+    <link rel="privacy-policy" href="./privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <script type="application/ld+json">
       {
@@ -49,7 +49,7 @@
         "hasPart": {
           "@type": "WebPageElement",
           "name": "Privacy Policy",
-          "url": "privacy.html",
+          "url": "./privacy.html",
           "text": "Vindem Labs LLC does not share, sell, or rent your mobile phone number or any personal information collected through SMS messaging with third parties for their marketing purposes. Your mobile number will only be used to send you the SMS messages you have opted in to receive."
         }
       }
@@ -1261,7 +1261,7 @@
           <a href="#focus">Sectors</a>
           <a href="#engine">Approach</a>
           <a href="#roadmap">Roadmap</a>
-          <a href="privacy.html">Privacy</a>
+          <a href="./privacy.html">Privacy</a>
           <a class="button secondary" href="#contact">Contact</a>
         </nav>
 
@@ -1279,7 +1279,7 @@
             <a href="#focus">Sectors</a>
             <a href="#engine">Approach</a>
             <a href="#roadmap">Roadmap</a>
-            <a href="privacy.html">Privacy</a>
+            <a href="./privacy.html">Privacy</a>
             <a href="#contact">Contact</a>
           </div>
         </details>
@@ -1891,10 +1891,7 @@
                 </p>
               </div>
 
-              <p class="privacy-note">
-                Review the standalone <a href="privacy.html">Vindem Labs privacy policy</a> for SMS
-                and mobile information handling terms.
-              </p>
+              <p class="privacy-note"><a href="./privacy.html">Privacy policy</a></p>
             </form>
           </div>
         </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="index, follow" />
     <meta name="author" content="Vindem Labs LLC" />
     <meta name="theme-color" content="#d8fbf5" />
-    <link rel="canonical" href="privacy.html" />
+    <link rel="canonical" href="./privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <style>
       :root {
@@ -129,7 +129,7 @@
           </p>
         </section>
 
-        <a class="back-link" href="https://vindem.tech">Return to vindem.tech</a>
+        <a class="back-link" href="https://vindem.tech/">Back to Vindem Labs</a>
       </article>
     </main>
   </body>


### PR DESCRIPTION
This PR tracks a focused privacy UX correction from the `ux-only` branch.\n\nTracking issue: #47\n\nCurrent update:\n- make top and mobile Privacy links use explicit `./privacy.html` URLs\n- make homepage privacy metadata and JSON-LD use `./privacy.html`\n- reduce the contact-form privacy note to a simple `Privacy policy` link\n- keep `privacy.html` crawler-readable and update its button copy to `Back to Vindem Labs` pointing to `https://vindem.tech/`\n\nTests:\n- HTML parse check for `docs/index.html` and `docs/privacy.html`\n- `git diff --check`\n- live check: `https://vindem.tech/privacy.html` currently returns HTTP 200