### PR TITLE
Point privacy links to production policy page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>Vindem Labs | Web, Mobile, Software, and Digital Platforms</title>
     <meta
       name="description"
-      content="Vindem Labs LLC builds web, mobile, software, and digital platforms across PropTech, AI education, property operations, IoT, and publisher websites. View the SMS and mobile privacy policy at privacy.html."
+      content="Vindem Labs LLC builds web, mobile, software, and digital platforms across PropTech, AI education, property operations, IoT, and publisher websites. View the SMS and mobile privacy policy at https://vindem.tech/privacy.html."
     />
     <meta
       name="keywords"
@@ -20,7 +20,7 @@
     <meta property="og:title" content="Vindem Labs" />
     <meta
       property="og:description"
-      content="Vindem Labs LLC creates digital products, software platforms, websites, and connected web experiences. The SMS and mobile privacy policy is available at privacy.html."
+      content="Vindem Labs LLC creates digital products, software platforms, websites, and connected web experiences. The SMS and mobile privacy policy is available at https://vindem.tech/privacy.html."
     />
     <meta property="og:site_name" content="Vindem Labs" />
     <meta property="og:type" content="website" />
@@ -29,10 +29,10 @@
     <meta name="twitter:title" content="Vindem Labs" />
     <meta
       name="twitter:description"
-      content="Web, mobile, software, and digital platforms from Vindem Labs LLC, with the SMS and mobile privacy policy available at privacy.html."
+      content="Web, mobile, software, and digital platforms from Vindem Labs LLC, with the SMS and mobile privacy policy available at https://vindem.tech/privacy.html."
     />
-    <meta name="privacy-policy" content="./privacy.html" />
-    <link rel="privacy-policy" href="./privacy.html" />
+    <meta name="privacy-policy" content="https://vindem.tech/privacy.html" />
+    <link rel="privacy-policy" href="https://vindem.tech/privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <script type="application/ld+json">
       {
@@ -49,7 +49,7 @@
         "hasPart": {
           "@type": "WebPageElement",
           "name": "Privacy Policy",
-          "url": "./privacy.html",
+          "url": "https://vindem.tech/privacy.html",
           "text": "Vindem Labs LLC does not share, sell, or rent your mobile phone number or any personal information collected through SMS messaging with third parties for their marketing purposes. Your mobile number will only be used to send you the SMS messages you have opted in to receive."
         }
       }
@@ -1261,7 +1261,7 @@
           <a href="#focus">Sectors</a>
           <a href="#engine">Approach</a>
           <a href="#roadmap">Roadmap</a>
-          <a href="./privacy.html">Privacy</a>
+          <a href="https://vindem.tech/privacy.html">Privacy</a>
           <a class="button secondary" href="#contact">Contact</a>
         </nav>
 
@@ -1279,7 +1279,7 @@
             <a href="#focus">Sectors</a>
             <a href="#engine">Approach</a>
             <a href="#roadmap">Roadmap</a>
-            <a href="./privacy.html">Privacy</a>
+            <a href="https://vindem.tech/privacy.html">Privacy</a>
             <a href="#contact">Contact</a>
           </div>
         </details>
@@ -1891,7 +1891,7 @@
                 </p>
               </div>
 
-              <p class="privacy-note"><a href="./privacy.html">Privacy policy</a></p>
+              <p class="privacy-note"><a href="https://vindem.tech/privacy.html">Privacy policy</a></p>
             </form>
           </div>
         </div>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -11,7 +11,7 @@
     <meta name="robots" content="index, follow" />
     <meta name="author" content="Vindem Labs LLC" />
     <meta name="theme-color" content="#d8fbf5" />
-    <link rel="canonical" href="./privacy.html" />
+    <link rel="canonical" href="https://vindem.tech/privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <style>
       :root {


### PR DESCRIPTION
This PR fixes the Privacy link target by using the production privacy URL directly.\n\nTracking issue: #49\n\nCurrent update:\n- top and mobile Privacy links now point to `https://vindem.tech/privacy.html`\n- contact-form Privacy policy link now points to `https://vindem.tech/privacy.html`\n- homepage privacy metadata and JSON-LD now point to `https://vindem.tech/privacy.html`\n- `privacy.html` canonical now points to `https://vindem.tech/privacy.html`\n\nTests:\n- grep check confirms no `#privacy-policy` references remain in `docs/index.html` or `docs/privacy.html`\n- HTML parse check for `docs/index.html` and `docs/privacy.html`\n- `git diff --check`