### PR TITLE
Remove custom privacy policy head links

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,8 +31,6 @@
       name="twitter:description"
       content="Web, mobile, software, and digital platforms from Vindem Labs LLC, with the SMS and mobile privacy policy available at https://vindem.tech/privacy.html."
     />
-    <meta name="privacy-policy" content="https://vindem.tech/privacy.html" />
-    <link rel="privacy-policy" href="https://vindem.tech/privacy.html" />
     <link rel="icon" href="assets/favicon.svg?v=10" type="image/svg+xml" />
     <script type="application/ld+json">
       {


### PR DESCRIPTION
This PR removes nonstandard privacy-policy head tags that may confuse crawlers or validators.\n\nTracking issue: #51\n\nCurrent update:\n- remove `<meta name="privacy-policy">` from the homepage\n- remove `<link rel="privacy-policy">` from the homepage\n- keep normal visible Privacy anchors pointed to `https://vindem.tech/privacy.html`\n- keep `privacy.html` canonical pointed to `https://vindem.tech/privacy.html`\n\nTests:\n- grep check confirms no `rel="privacy-policy"`, `name="privacy-policy"`, or `#privacy-policy` references remain\n- HTML parse check for `docs/index.html` and `docs/privacy.html`\n- `git diff --check`