### PR TITLE
Use email client for contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Static GitHub Pages site for Vindem Labs.
 
 - `docs/`: public web root for GitHub Pages hosting
 - `docs/index.html`: the full single-page site
-- `docs/config.js`: public client-side form relay configuration
+- `docs/config.js`: public client-side contact email configuration
 - `docs/assets/favicon.svg`: browser icon
 - `docs/assets/og-card.svg`: social sharing preview
 - `docs/.nojekyll`: tells GitHub Pages to serve files as-is
@@ -23,15 +23,8 @@ history so downstream hosts can pull it without reconciling force-rewritten comm
 
 ## Contact form
 
-The contact form is designed for a static hosting setup and does not display a public email
-address on the page.
+The contact form is designed for a static hosting setup. It opens the visitor's email client with
+the form details prefilled and addressed to `info@vindem.tech`; no backend or hosted form relay is
+required.
 
-To route submissions privately to `vindem.labs@gmail.com`:
-
-1. Create a Web3Forms account or another hosted form relay.
-2. Set `vindem.labs@gmail.com` as the destination inbox in that service.
-3. Put the provided public access key into `docs/config.js` as `formAccessKey`.
-4. Publish the updated site.
-
-The access key is expected to be public in the browser for this kind of static form relay. The
-email destination itself remains hidden from the page UI and markup.
+The destination email is configured in `docs/config.js` as `contactEmail`.

--- a/docs/config.js
+++ b/docs/config.js
@@ -1,6 +1,5 @@
 window.VINDEM_LABS_CONFIG = {
-  formEndpoint: "https://api.web3forms.com/submit",
-  formAccessKey: "",
+  contactEmail: "info@vindem.tech",
 };
 
 (() => {
@@ -53,21 +52,4 @@ window.VINDEM_LABS_CONFIG = {
     footerBar.appendChild(footerLinks);
   }
 
-  const contactForm = document.getElementById("contact-form");
-  const fallback = document.getElementById("contact-fallback");
-  const config = window.VINDEM_LABS_CONFIG || {};
-
-  if (!contactForm || !fallback) {
-    return;
-  }
-
-  fallback.setAttribute("role", "status");
-
-  if (config.formAccessKey) {
-    return;
-  }
-
-  contactForm.querySelectorAll(".field input, .field textarea").forEach((field) => {
-    field.disabled = true;
-  });
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -961,6 +961,25 @@
         color: var(--brand-deep);
       }
 
+      .timeline-outcomes {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 1rem 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .timeline-outcomes li {
+        padding: 0.48rem 0.62rem;
+        border-radius: 0.6rem;
+        background: rgba(255, 255, 255, 0.72);
+        color: var(--brand-deep);
+        font-size: 0.78rem;
+        font-weight: 800;
+        line-height: 1.25;
+      }
+
       .timeline-card,
       .timeline-card strong span {
         z-index: 1;
@@ -1981,6 +2000,11 @@
                 Clarify the need, the audience, the business context, and the right digital shape
                 for the opportunity.
               </p>
+              <ul class="timeline-outcomes" aria-label="Clarify outputs">
+                <li>Decision brief</li>
+                <li>Audience needs</li>
+                <li>Initial scope</li>
+              </ul>
             </article>
             <article class="timeline-card">
               <strong><span aria-hidden="true">02</span>Build</strong>
@@ -1988,6 +2012,11 @@
                 Design and build the right product, platform, or website with attention to
                 usability, technical quality, and future scalability.
               </p>
+              <ul class="timeline-outcomes" aria-label="Build outputs">
+                <li>Working product</li>
+                <li>Launch-ready UX</li>
+                <li>Integration plan</li>
+              </ul>
             </article>
             <article class="timeline-card">
               <strong><span aria-hidden="true">03</span>Improve</strong>
@@ -1995,6 +2024,11 @@
                 Improve, extend, and support the platform after launch so it continues to deliver
                 value as the business evolves.
               </p>
+              <ul class="timeline-outcomes" aria-label="Improve outputs">
+                <li>Usage feedback</li>
+                <li>Priority updates</li>
+                <li>Support path</li>
+              </ul>
             </article>
           </div>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1111,65 +1111,6 @@
         font-size: 0.92rem;
       }
 
-      .contact-fallback {
-        display: none;
-        width: 100%;
-        padding: 1rem 1.05rem;
-        border: 1px solid rgba(7, 84, 93, 0.16);
-        border-left: 4px solid var(--accent);
-        border-radius: 1rem;
-        background: rgba(255, 243, 221, 0.52);
-        color: var(--ink);
-        font-size: 0.92rem;
-        line-height: 1.55;
-      }
-
-      .contact-fallback p {
-        margin: 0;
-        color: var(--ink);
-      }
-
-      .contact-fallback strong {
-        display: block;
-        margin-bottom: 0.25rem;
-        color: var(--brand-deep);
-      }
-
-      .contact-fallback a {
-        display: inline-flex;
-        align-items: center;
-        min-height: 2.35rem;
-        margin-top: 0.7rem;
-        padding: 0.55rem 0.75rem;
-        border-radius: 0.65rem;
-        background: rgba(7, 84, 93, 0.09);
-        color: var(--brand-deep);
-        font-weight: 800;
-      }
-
-      .contact-fallback a:hover,
-      .contact-fallback a:focus-visible {
-        background: rgba(0, 167, 179, 0.16);
-        outline: 2px solid rgba(0, 167, 179, 0.25);
-        outline-offset: 2px;
-      }
-
-      .contact-form.is-unavailable .contact-fallback {
-        display: grid;
-        gap: 0.25rem;
-        box-shadow: 0 16px 34px rgba(7, 84, 93, 0.09);
-      }
-
-      .contact-form.is-unavailable .form-intro {
-        border-color: rgba(7, 84, 93, 0.12);
-        background: rgba(255, 255, 255, 0.78);
-      }
-
-      .contact-form.is-unavailable .form-meta,
-      .contact-form.is-unavailable .form-grid {
-        display: none;
-      }
-
       .privacy-note {
         display: grid;
         gap: 0.65rem;
@@ -2077,16 +2018,6 @@
             </aside>
 
             <form class="contact-form" id="contact-form" novalidate>
-              <div class="contact-fallback" id="contact-fallback" role="status">
-                <strong>Contact form temporarily unavailable</strong>
-                <p>
-                  Message delivery is being configured before inquiries can be sent. The planning
-                  prompts below remain available so you can shape the right project context before
-                  the form opens.
-                </p>
-                <a href="https://vindem.tech/privacy.html?v=20260505">Review privacy terms</a>
-              </div>
-
               <div class="form-intro" aria-labelledby="contact-form-title">
                 <div>
                   <strong id="contact-form-title">Start with the useful context.</strong>
@@ -2184,22 +2115,7 @@
       const contactForm = document.getElementById("contact-form");
       const formStatus = document.getElementById("form-status");
       const siteConfig = window.VINDEM_LABS_CONFIG || {};
-      const formEndpoint = siteConfig.formEndpoint || "https://api.web3forms.com/submit";
-      const formAccessKey = siteConfig.formAccessKey || "";
-
-      if (contactForm && !formAccessKey) {
-        contactForm.classList.add("is-unavailable");
-        const submitButton = contactForm.querySelector('button[type="submit"]');
-
-        if (submitButton) {
-          submitButton.disabled = true;
-          submitButton.textContent = "Message unavailable";
-        }
-
-        if (formStatus) {
-          formStatus.textContent = "Message delivery is temporarily unavailable.";
-        }
-      }
+      const contactEmail = siteConfig.contactEmail || "info@vindem.tech";
 
       const selectTab = (tab, shouldFocus = false) => {
           const targetId = tab.getAttribute("aria-controls");
@@ -2275,49 +2191,21 @@
             return;
           }
 
-          if (!formAccessKey) {
-            formStatus.textContent = "Message delivery is temporarily unavailable. Please try again shortly.";
-            return;
-          }
+          const subject = encodeURIComponent("New inquiry from vindem.tech");
+          const body = encodeURIComponent(
+            [
+              `Name: ${contactForm.name.value.trim()}`,
+              `Company: ${contactForm.company.value.trim() || "Not provided"}`,
+              `Email: ${contactForm.email.value.trim()}`,
+              `Area of interest: ${contactForm.interest.value.trim()}`,
+              "",
+              "Project details:",
+              contactForm.message.value.trim(),
+            ].join("\n")
+          );
 
-          formStatus.textContent = "Sending your message...";
-
-          const payload = {
-            access_key: formAccessKey,
-            subject: "New inquiry from vindemlabs.com",
-            from_name: "Vindem Labs",
-            name: contactForm.name.value.trim(),
-            company: contactForm.company.value.trim(),
-            email: contactForm.email.value.trim(),
-            interest: contactForm.interest.value.trim(),
-            message: contactForm.message.value.trim(),
-            botcheck: contactForm.botcheck.checked ? "1" : "",
-          };
-
-          try {
-            const response = await fetch(formEndpoint, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Accept: "application/json",
-              },
-              body: JSON.stringify(payload),
-            });
-
-            const result = await response.json();
-
-            if (!response.ok || !result.success) {
-              throw new Error(result.message || "Unable to send message right now.");
-            }
-
-            contactForm.reset();
-            formStatus.textContent = "Your message has been sent. Thank you.";
-          } catch (error) {
-            formStatus.textContent =
-              error instanceof Error
-                ? error.message
-                : "Something went wrong while sending your message.";
-          }
+          window.location.href = `mailto:${contactEmail}?subject=${subject}&body=${body}`;
+          formStatus.textContent = "Opening your email app to send the message.";
         });
       }
     </script>


### PR DESCRIPTION
This PR switches the static contact form to a direct email-client flow.\n\nTracking issue: #57\n\nCurrent update:\n- configure `info@vindem.tech` as the public contact destination\n- remove the Web3Forms/formAccessKey dependency\n- remove the disabled/unavailable contact-form state\n- keep form fields enabled and open a prefilled `mailto:` message on submit\n- update README contact-form documentation\n\nAlso included from the current rolling `ux-only` branch:\n- clarify engagement path outputs\n\nTests:\n- HTML parse check for `docs/index.html` and `docs/privacy.html`\n- `git diff --check`\n- grep check for stale relay/disabled-form references