### PR TITLE
Add serverless contact endpoint option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ the form details prefilled and addressed to `info@vindem.tech`; no backend or ho
 required.
 
 The destination email is configured in `docs/config.js` as `contactEmail`.
+
+To submit without opening an email client, deploy the Worker in `serverless/contact-worker.js` and
+set `contactEndpoint` in `docs/config.js` to the Worker URL. The static form will then POST to that
+endpoint and email `info@vindem.tech` from the Worker.

--- a/docs/config.js
+++ b/docs/config.js
@@ -1,5 +1,6 @@
 window.VINDEM_LABS_CONFIG = {
   contactEmail: "info@vindem.tech",
+  contactEndpoint: "",
 };
 
 (() => {

--- a/docs/index.html
+++ b/docs/index.html
@@ -2116,6 +2116,7 @@
       const formStatus = document.getElementById("form-status");
       const siteConfig = window.VINDEM_LABS_CONFIG || {};
       const contactEmail = siteConfig.contactEmail || "info@vindem.tech";
+      const contactEndpoint = siteConfig.contactEndpoint || "";
 
       const selectTab = (tab, shouldFocus = false) => {
           const targetId = tab.getAttribute("aria-controls");
@@ -2191,16 +2192,55 @@
             return;
           }
 
+          const payload = {
+            name: contactForm.name.value.trim(),
+            company: contactForm.company.value.trim(),
+            email: contactForm.email.value.trim(),
+            interest: contactForm.interest.value.trim(),
+            message: contactForm.message.value.trim(),
+            botcheck: contactForm.botcheck.checked ? "1" : "",
+          };
+
+          if (contactEndpoint) {
+            formStatus.textContent = "Sending your message...";
+
+            try {
+              const response = await fetch(contactEndpoint, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  Accept: "application/json",
+                },
+                body: JSON.stringify(payload),
+              });
+              const result = await response.json().catch(() => ({}));
+
+              if (!response.ok || result.success === false) {
+                throw new Error(result.message || "Unable to send message right now.");
+              }
+
+              contactForm.reset();
+              formStatus.textContent = "Your message has been sent. Thank you.";
+            } catch (error) {
+              formStatus.textContent =
+                error instanceof Error
+                  ? error.message
+                  : "Something went wrong while sending your message.";
+            }
+
+            return;
+          }
+
           const subject = encodeURIComponent("New inquiry from vindem.tech");
           const body = encodeURIComponent(
             [
-              `Name: ${contactForm.name.value.trim()}`,
-              `Company: ${contactForm.company.value.trim() || "Not provided"}`,
-              `Email: ${contactForm.email.value.trim()}`,
-              `Area of interest: ${contactForm.interest.value.trim()}`,
+              `Name: ${payload.name}`,
+              `Company: ${payload.company || "Not provided"}`,
+              `Email: ${payload.email}`,
+              `Area of interest: ${payload.interest}`,
               "",
               "Project details:",
-              contactForm.message.value.trim(),
+              payload.message,
             ].join("\n")
           );
 

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -1,0 +1,36 @@
+# Contact Worker
+
+Tiny Cloudflare Worker contact endpoint for the static Vindem Labs site.
+
+## Required Secrets
+
+- `RESEND_API_KEY`: Resend API key used to send email.
+
+## Optional Variables
+
+- `CONTACT_TO_EMAIL`: defaults to `info@vindem.tech`
+- `CONTACT_FROM_EMAIL`: defaults to `Vindem Labs <contact@vindem.tech>`
+- `ALLOWED_ORIGIN`: defaults to `https://vindem.tech`
+
+## Static Site Configuration
+
+After deploying the Worker, put its public endpoint in `docs/config.js`:
+
+```js
+window.VINDEM_LABS_CONFIG = {
+  contactEmail: "info@vindem.tech",
+  contactEndpoint: "https://your-worker.your-subdomain.workers.dev",
+};
+```
+
+If `contactEndpoint` is empty, the site falls back to opening a prefilled email to
+`info@vindem.tech`.
+
+## Deploy
+
+From this folder:
+
+```sh
+wrangler secret put RESEND_API_KEY
+wrangler deploy
+```

--- a/serverless/contact-worker.js
+++ b/serverless/contact-worker.js
@@ -1,0 +1,97 @@
+const corsHeaders = (origin) => ({
+  "Access-Control-Allow-Origin": origin,
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+});
+
+const json = (body, status = 200, origin = "*") =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders(origin),
+      "Content-Type": "application/json; charset=utf-8",
+    },
+  });
+
+const clean = (value) => String(value || "").trim();
+
+export default {
+  async fetch(request, env) {
+    const allowedOrigin = env.ALLOWED_ORIGIN || "https://vindem.tech";
+    const requestOrigin = request.headers.get("Origin") || "";
+    const responseOrigin = requestOrigin === allowedOrigin ? requestOrigin : allowedOrigin;
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(responseOrigin),
+      });
+    }
+
+    if (request.method !== "POST") {
+      return json({ success: false, message: "Method not allowed." }, 405, responseOrigin);
+    }
+
+    let input;
+
+    try {
+      input = await request.json();
+    } catch {
+      return json({ success: false, message: "Invalid request body." }, 400, responseOrigin);
+    }
+
+    if (clean(input.botcheck)) {
+      return json({ success: true }, 200, responseOrigin);
+    }
+
+    const name = clean(input.name);
+    const company = clean(input.company);
+    const email = clean(input.email);
+    const interest = clean(input.interest);
+    const message = clean(input.message);
+
+    if (!name || !email || !interest || !message) {
+      return json({ success: false, message: "Please complete the required fields." }, 400, responseOrigin);
+    }
+
+    if (!env.RESEND_API_KEY) {
+      return json({ success: false, message: "Contact delivery is not configured." }, 500, responseOrigin);
+    }
+
+    const to = env.CONTACT_TO_EMAIL || "info@vindem.tech";
+    const from = env.CONTACT_FROM_EMAIL || "Vindem Labs <contact@vindem.tech>";
+    const replyTo = email;
+    const text = [
+      "New inquiry from vindem.tech",
+      "",
+      `Name: ${name}`,
+      `Company: ${company || "Not provided"}`,
+      `Email: ${email}`,
+      `Area of interest: ${interest}`,
+      "",
+      "Project details:",
+      message,
+    ].join("\n");
+
+    const resendResponse = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env.RESEND_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from,
+        to,
+        reply_to: replyTo,
+        subject: "New inquiry from vindem.tech",
+        text,
+      }),
+    });
+
+    if (!resendResponse.ok) {
+      return json({ success: false, message: "Unable to send message right now." }, 502, responseOrigin);
+    }
+
+    return json({ success: true }, 200, responseOrigin);
+  },
+};

--- a/serverless/wrangler.toml
+++ b/serverless/wrangler.toml
@@ -1,0 +1,3 @@
+name = "vindem-labs-contact"
+main = "contact-worker.js"
+compatibility_date = "2025-12-01"


### PR DESCRIPTION
This PR adds an optional serverless contact submission path while preserving the current static fallback.\n\nTracking issue: #59\n\nCurrent update:\n- add `contactEndpoint` support in `docs/config.js`\n- submit the form in-page via `fetch(contactEndpoint)` when configured\n- keep the existing prefilled `mailto:info@vindem.tech` fallback when `contactEndpoint` is empty\n- add `serverless/contact-worker.js`, a tiny Cloudflare Worker that sends through Resend\n- add `serverless/wrangler.toml` and deployment notes\n\nTests:\n- `node --check serverless/contact-worker.js`\n- HTML parse check for `docs/index.html` and `docs/privacy.html`\n- `git diff --check`