### PR TITLE
Restore detailed offerings layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -820,6 +820,14 @@
 
       .stream-grid {
         display: grid;
+        grid-template-columns: 1.3fr 0.9fr;
+        gap: 1rem;
+      }
+
+      .stream-content,
+      .stream-side,
+      .sub-list {
+        display: grid;
         gap: 1rem;
       }
 
@@ -858,6 +866,16 @@
         outline-offset: 2px;
       }
 
+      .sub-item,
+      .checkpoint {
+        padding: 1rem;
+        border-radius: 0.8rem;
+        background: rgba(19, 49, 56, 0.04);
+        border: 1px solid rgba(19, 49, 56, 0.06);
+      }
+
+      .sub-item strong,
+      .checkpoint strong,
       .pillar h3,
       .path-card h3,
       .contact-card h3 {
@@ -1503,12 +1521,36 @@
                       that need strong user experiences, clear journeys, and scalable digital
                       products across web and mobile.
                     </p>
+                    <div class="sub-list">
+                      <div class="sub-item">
+                        <strong>Product-led experiences</strong>
+                        <p>Customer apps, member portals, self-service flows, and interactive tools built around everyday usage.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Mobile-first journeys</strong>
+                        <p>Responsive web apps and native-feeling mobile experiences for audiences that expect speed, clarity, and convenience.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Growth-ready foundations</strong>
+                        <p>Analytics-aware application builds that support retention, iteration, and future feature expansion.</p>
+                      </div>
+                    </div>
+                  </div>
+                  <aside class="stream-side">
+                    <div class="checkpoint">
+                      <strong>Typical use cases</strong>
+                      <p>Customer apps, subscription products, booking flows, property experiences, and education-focused digital tools.</p>
+                    </div>
+                    <div class="checkpoint">
+                      <strong>Best fit</strong>
+                      <p>Teams looking to launch or modernize digital products where usability and adoption matter as much as the technology underneath.</p>
+                    </div>
                     <div class="stat-list">
                       <span>Customer apps</span>
                       <span>Member portals</span>
                       <span>Mobile UX</span>
                     </div>
-                  </div>
+                  </aside>
                 </div>
               </article>
 
@@ -1527,12 +1569,36 @@
                       work more clearly, automate repetitive processes, and gain visibility across
                       critical business operations.
                     </p>
+                    <div class="sub-list">
+                      <div class="sub-item">
+                        <strong>Operational dashboards</strong>
+                        <p>Software interfaces for tracking workflows, performance, team activity, and operational decision-making.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Process digitization</strong>
+                        <p>Business tools that replace fragmented spreadsheets, emails, and manual coordination with streamlined systems.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Sector-specific platforms</strong>
+                        <p>Tailored solutions for property operations, AI education workflows, and connected environments with real reporting needs.</p>
+                      </div>
+                    </div>
+                  </div>
+                  <aside class="stream-side">
+                    <div class="checkpoint">
+                      <strong>Typical use cases</strong>
+                      <p>Property management software, internal tools, control centers, analytics platforms, and business workflow systems.</p>
+                    </div>
+                    <div class="checkpoint">
+                      <strong>Best fit</strong>
+                      <p>Organizations that need dependable custom software or new digital products to support teams, clients, or field operations.</p>
+                    </div>
                     <div class="stat-list">
                       <span>Dashboards</span>
                       <span>Automation</span>
                       <span>Internal tools</span>
                     </div>
-                  </div>
+                  </aside>
                 </div>
               </article>
 
@@ -1551,12 +1617,36 @@
                       trusted partner across discovery, design, development, delivery, and
                       continuous improvement.
                     </p>
+                    <div class="sub-list">
+                      <div class="sub-item">
+                        <strong>Discovery and product framing</strong>
+                        <p>Clarifying the problem, shaping the roadmap, and defining the right scope before build work accelerates.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Delivery and implementation</strong>
+                        <p>Building applications, websites, internal tools, and connected digital services with a practical execution focus.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Ongoing support</strong>
+                        <p>Post-launch evolution, maintenance, optimization, and product support for businesses that want continuity.</p>
+                      </div>
+                    </div>
+                  </div>
+                  <aside class="stream-side">
+                    <div class="checkpoint">
+                      <strong>Typical use cases</strong>
+                      <p>New digital products, platform upgrades, connected systems, and ongoing delivery support.</p>
+                    </div>
+                    <div class="checkpoint">
+                      <strong>Best fit</strong>
+                      <p>Teams that want a capable digital partner rather than a disconnected set of freelancers or narrowly scoped vendors.</p>
+                    </div>
                     <div class="stat-list">
                       <span>Advisory</span>
                       <span>Delivery</span>
                       <span>Retainers</span>
                     </div>
-                  </div>
+                  </aside>
                 </div>
               </article>
 
@@ -1575,12 +1665,36 @@
                       brands or ventures that want stronger digital reach, better search
                       discoverability, and scalable web properties built around content.
                     </p>
+                    <div class="sub-list">
+                      <div class="sub-item">
+                        <strong>Content-driven websites</strong>
+                        <p>Editorial platforms, resource hubs, guides, and structured publishing experiences that support long-term growth.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Monetized media properties</strong>
+                        <p>Websites designed around advertising, affiliate partnerships, lead generation, or category authority.</p>
+                      </div>
+                      <div class="sub-item">
+                        <strong>Specialized publishing builds</strong>
+                        <p>Platforms for sectors such as PropTech, AI education, or comparison-based digital publishing models.</p>
+                      </div>
+                    </div>
+                  </div>
+                  <aside class="stream-side">
+                    <div class="checkpoint">
+                      <strong>Typical use cases</strong>
+                      <p>Publisher websites, affiliate content platforms, niche media brands, and structured SEO-led web properties.</p>
+                    </div>
+                    <div class="checkpoint">
+                      <strong>Best fit</strong>
+                      <p>Businesses that want their digital presence to do more than present information and instead become an active acquisition asset.</p>
+                    </div>
                     <div class="stat-list">
                       <span>SEO platforms</span>
                       <span>Media sites</span>
                       <span>Affiliate models</span>
                     </div>
-                  </div>
+                  </aside>
                 </div>
               </article>
             </div>
@@ -1680,7 +1794,7 @@
               </p>
             </article>
             <article class="pillar">
-              <h3>Long-term usefulness</h3>
+              <h3>Durable product foundations</h3>
               <p>
                 The goal is to create software and digital platforms that remain clear, extensible,
                 and valuable as the business around them grows.


### PR DESCRIPTION
Summary:
- Restored the richer Offerings section layout with sub-cards and side context.
- Kept the previously removed roadmap, engagement-snapshot, and verbose contact sections out.
- Replaced "Long-term usefulness" with "Durable product foundations" for a more professional tone.

Screenshots:

Screenshot capture was not completed in this run because local headless Chrome launch required escalated execution and the current session hit its usage limit. No stale screenshots were reused.

Validation:
- git diff --check
- scanned for removed bloat markers and tooling markers

Closes #82