### PR TITLE
Rolling UX updates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1239,6 +1239,14 @@
           gap: 0.55rem;
           padding: 0.55rem;
           border-radius: 1.15rem;
+          position: sticky;
+          top: 5rem;
+          z-index: 5;
+          background:
+            linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(250, 255, 252, 0.86)),
+            radial-gradient(circle at 0 0, rgba(183, 242, 234, 0.56), transparent 12rem);
+          box-shadow: 0 18px 38px rgba(7, 84, 93, 0.12);
+          backdrop-filter: blur(16px);
         }
 
         .stream-mobile-summary {
@@ -1277,6 +1285,7 @@
           border-radius: 0.9rem;
           display: grid;
           place-items: center;
+          box-shadow: none;
         }
 
         .stream-tab::before {
@@ -1289,6 +1298,13 @@
         .stream-tab:focus-visible,
         .stream-tab[aria-selected="true"] {
           transform: translateY(-2px);
+        }
+
+        .stream-tab[aria-selected="true"] {
+          background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(216, 251, 245, 0.78));
+          box-shadow:
+            inset 0 0 0 1px rgba(0, 167, 179, 0.22),
+            0 12px 24px rgba(7, 84, 93, 0.1);
         }
 
         .stream-tab strong {

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,14 +711,21 @@
 
       .stream-shell {
         display: grid;
-        grid-template-columns: 290px 1fr;
-        gap: 1rem;
+        grid-template-columns: minmax(17rem, 19.5rem) minmax(0, 1fr);
+        gap: 1.15rem;
         align-items: start;
       }
 
       .stream-tabs {
         display: grid;
-        gap: 0.8rem;
+        gap: 0.72rem;
+        padding: 0.7rem;
+        border: 1px solid rgba(0, 126, 139, 0.1);
+        border-radius: 1.45rem;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.74), rgba(255, 255, 255, 0.48)),
+          radial-gradient(circle at 0 0, rgba(183, 242, 234, 0.52), transparent 12rem);
+        box-shadow: 0 16px 34px rgba(7, 84, 93, 0.07);
       }
 
       .stream-mobile-summary {
@@ -731,13 +738,18 @@
         position: relative;
         overflow: hidden;
         text-align: left;
-        padding: 1.1rem 1.15rem;
-        border-radius: 1.2rem;
+        padding: 1.05rem 1.1rem 1.05rem 1.25rem;
+        border-radius: 1rem;
         border: 1px solid var(--line);
         background: rgba(255, 255, 255, 0.62);
         color: var(--text);
         cursor: pointer;
-        transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+        box-shadow: 0 8px 22px rgba(7, 84, 93, 0.045);
+        transition:
+          transform 180ms ease,
+          border-color 180ms ease,
+          background 180ms ease,
+          box-shadow 180ms ease;
       }
 
       .stream-tab::before {
@@ -755,12 +767,12 @@
       .stream-tab[aria-selected="true"] {
         transform: translateX(4px);
         border-color: rgba(0, 167, 179, 0.42);
-        background: rgba(190, 236, 231, 0.5);
+        background: rgba(255, 255, 255, 0.88);
       }
 
       .stream-tab[aria-selected="true"] {
         color: var(--brand-deep);
-        box-shadow: 0 16px 34px rgba(7, 84, 93, 0.12);
+        box-shadow: 0 16px 34px rgba(7, 84, 93, 0.14);
       }
 
       .stream-tab[aria-selected="true"]::before {
@@ -1225,6 +1237,8 @@
         .stream-tabs {
           grid-template-columns: repeat(2, minmax(0, 1fr));
           gap: 0.55rem;
+          padding: 0.55rem;
+          border-radius: 1.15rem;
         }
 
         .stream-mobile-summary {

--- a/docs/index.html
+++ b/docs/index.html
@@ -229,7 +229,11 @@
         justify-content: flex-end;
       }
 
-      nav a {
+      .site-header nav a {
+        display: inline-flex;
+        align-items: center;
+        min-height: 2.5rem;
+        padding: 0 0.45rem;
         position: relative;
         color: var(--muted);
         font-size: 0.95rem;
@@ -237,8 +241,8 @@
         transition: color 180ms ease, background 180ms ease, box-shadow 180ms ease;
       }
 
-      nav a:hover,
-      nav a:focus-visible {
+      .site-header nav a:hover,
+      .site-header nav a:focus-visible {
         color: var(--text);
       }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1340,6 +1340,16 @@
           justify-self: start;
         }
 
+        .form-meta {
+          display: grid;
+          align-items: stretch;
+          gap: 0.75rem;
+        }
+
+        .form-meta .button {
+          width: 100%;
+        }
+
         .delivery-item {
           grid-template-columns: 1fr;
           gap: 0.25rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1156,6 +1156,10 @@
           min-height: auto;
         }
 
+        .stream-grid {
+          grid-template-columns: 1fr;
+        }
+
         h1 {
           font-size: 3.7rem;
         }


### PR DESCRIPTION
This PR tracks rolling visual UX-only improvements from the `ux-only` branch.

Latest change:
- Improves the mobile contact form action layout so the submit area stacks cleanly and the primary button spans the form width on narrow screens.

Screenshots:
- Before: not captured. The in-app Browser execution surface was unavailable, Computer Use access to Chrome was denied, direct local Chrome headless screenshot capture exited without producing an image, and `npx playwright` could not install because network DNS resolution to npm was blocked.
- After: not captured for the same screenshot tooling limitations.

Validation:
- `curl -I http://127.0.0.1:8123/` returned `200 OK` from `docs/`.
- `git diff --check` passed.
- `tidy -qe docs/index.html` completed with existing warnings for the empty mobile menu icon spans only.