### PR TITLE
Rolling UX updates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -983,8 +983,18 @@
       .contact-form {
         display: grid;
         gap: 1rem;
+        position: relative;
+        overflow: hidden;
         background: rgba(255, 255, 255, 0.9);
         border-color: rgba(255, 255, 255, 0.9);
+      }
+
+      .contact-form::before {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto;
+        height: 5px;
+        background: linear-gradient(90deg, var(--brand), var(--accent));
       }
 
       .form-grid {
@@ -1012,6 +1022,12 @@
       }
 
       .required-mark {
+        display: inline-flex;
+        align-items: center;
+        min-height: 1.35rem;
+        padding: 0.18rem 0.45rem;
+        border-radius: 0.45rem;
+        background: rgba(0, 167, 179, 0.1);
         color: var(--brand-deep);
         font-size: 0.72rem;
         font-weight: 800;
@@ -1034,6 +1050,11 @@
         padding: 0.95rem 1rem;
         background: rgba(255, 255, 255, 0.88);
         color: var(--text);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+        transition:
+          background 180ms ease,
+          border-color 180ms ease,
+          box-shadow 180ms ease;
       }
 
       .field select {
@@ -1058,9 +1079,20 @@
       .field input:focus-visible,
       .field textarea:focus-visible,
       .field select:focus-visible {
-        outline: 2px solid rgba(0, 167, 179, 0.25);
-        outline-offset: 1px;
+        outline: none;
         border-color: rgba(0, 167, 179, 0.46);
+        background: #fff;
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.9),
+          0 0 0 3px rgba(0, 167, 179, 0.16),
+          0 12px 26px rgba(7, 84, 93, 0.08);
+      }
+
+      .field input:hover,
+      .field textarea:hover,
+      .field select:hover {
+        border-color: rgba(0, 167, 179, 0.3);
+        background: rgba(255, 255, 255, 0.98);
       }
 
       .form-meta {

--- a/docs/index.html
+++ b/docs/index.html
@@ -484,14 +484,27 @@
       }
 
       .hero-proof span {
-        padding: 0.55rem 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.48rem;
+        padding: 0.58rem 0.78rem;
         border: 1px solid rgba(0, 126, 139, 0.12);
         border-radius: 0.75rem;
-        background: rgba(255, 255, 255, 0.54);
+        background: rgba(255, 255, 255, 0.68);
         color: var(--ink);
         font-size: 0.86rem;
         font-weight: 700;
         box-shadow: 0 10px 24px rgba(7, 84, 93, 0.06);
+      }
+
+      .hero-proof span::before {
+        content: "";
+        width: 0.52rem;
+        height: 0.52rem;
+        border-radius: 999px;
+        flex: 0 0 auto;
+        background: linear-gradient(135deg, var(--brand), var(--accent));
+        box-shadow: 0 0 0 4px rgba(0, 167, 179, 0.08);
       }
 
       .metric-row {
@@ -523,6 +536,10 @@
         padding: 1.15rem;
         position: relative;
         overflow: hidden;
+        background:
+          linear-gradient(160deg, rgba(255, 255, 255, 0.86), rgba(236, 252, 246, 0.64)),
+          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.12), transparent 8rem);
+        border-color: rgba(255, 255, 255, 0.86);
         transition: transform 180ms ease, box-shadow 180ms ease;
       }
 
@@ -554,6 +571,7 @@
         font-size: 1.35rem;
         line-height: 1.16;
         letter-spacing: 0;
+        max-width: 13ch;
       }
 
       .metric-card span {
@@ -1295,6 +1313,10 @@
           place-items: center;
           text-align: center;
           line-height: 1.25;
+        }
+
+        .hero-proof span::before {
+          margin-bottom: 0.1rem;
         }
 
         .metric-row {

--- a/docs/index.html
+++ b/docs/index.html
@@ -851,10 +851,13 @@
         display: grid;
         gap: 0.45rem;
         margin-top: 0.25rem;
-        padding: 1rem;
+        padding: clamp(1rem, 2vw, 1.25rem);
         border: 1px solid rgba(0, 167, 179, 0.16);
         border-radius: 1rem;
-        background: linear-gradient(135deg, rgba(216, 251, 245, 0.58), rgba(255, 255, 255, 0.72));
+        background:
+          linear-gradient(135deg, rgba(216, 251, 245, 0.68), rgba(255, 255, 255, 0.78)),
+          linear-gradient(90deg, rgba(255, 152, 97, 0.28), transparent 48%);
+        box-shadow: inset 4px 0 0 rgba(255, 152, 97, 0.78);
       }
 
       .contact-direct span {
@@ -867,12 +870,14 @@
         justify-self: start;
         display: inline-flex;
         align-items: center;
+        max-width: 100%;
         min-height: 2.65rem;
         padding: 0.62rem 0.82rem;
         border-radius: 0.7rem;
         background: rgba(7, 84, 93, 0.09);
         color: var(--brand-deep);
         font-weight: 800;
+        overflow-wrap: anywhere;
       }
 
       .contact-direct a:hover,
@@ -958,19 +963,28 @@
 
       .contact-layout {
         display: grid;
-        grid-template-columns: 0.72fr 1.28fr;
-        gap: 1rem;
+        grid-template-columns: minmax(16rem, 0.64fr) minmax(0, 1.36fr);
+        gap: clamp(1rem, 2vw, 1.35rem);
+        align-items: start;
       }
 
       .contact-card {
         display: grid;
         gap: 1rem;
         align-content: start;
+        position: sticky;
+        top: 6.25rem;
+        overflow: hidden;
+        background:
+          linear-gradient(155deg, rgba(255, 255, 255, 0.94), rgba(221, 251, 240, 0.72)),
+          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.2), transparent 12rem);
       }
 
       .contact-form {
         display: grid;
         gap: 1rem;
+        background: rgba(255, 255, 255, 0.9);
+        border-color: rgba(255, 255, 255, 0.9);
       }
 
       .form-grid {
@@ -1166,6 +1180,10 @@
 
         .stream-panel {
           min-height: auto;
+        }
+
+        .contact-card {
+          position: static;
         }
 
         .stream-grid {

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,8 +193,25 @@
         display: flex;
         align-items: center;
         gap: 0.9rem;
+        padding: 0.35rem 0.45rem 0.35rem 0.35rem;
+        margin-left: -0.35rem;
+        border-radius: 1rem;
         font-weight: 800;
         letter-spacing: 0;
+        transition: background 180ms ease, box-shadow 180ms ease, transform 180ms ease;
+      }
+
+      .brand:hover {
+        background: rgba(255, 255, 255, 0.5);
+      }
+
+      .brand:focus-visible {
+        background: linear-gradient(135deg, rgba(216, 251, 245, 0.86), rgba(255, 248, 242, 0.76));
+        box-shadow:
+          0 0 0 3px rgba(255, 255, 255, 0.94),
+          0 0 0 6px rgba(0, 167, 179, 0.28),
+          0 10px 24px rgba(7, 84, 93, 0.12);
+        outline: none;
       }
 
       .brand-mark {

--- a/docs/index.html
+++ b/docs/index.html
@@ -885,14 +885,15 @@
       .contact-direct {
         display: grid;
         gap: 0.45rem;
-        margin-top: 0.25rem;
-        padding: clamp(1rem, 2vw, 1.25rem);
-        border: 1px solid rgba(0, 167, 179, 0.16);
-        border-radius: 1rem;
+        padding: clamp(1.1rem, 2vw, 1.35rem);
+        border: 1px solid rgba(0, 167, 179, 0.18);
+        border-radius: 1.25rem;
         background:
-          linear-gradient(135deg, rgba(216, 251, 245, 0.68), rgba(255, 255, 255, 0.78)),
-          linear-gradient(90deg, rgba(255, 152, 97, 0.28), transparent 48%);
-        box-shadow: inset 4px 0 0 rgba(255, 152, 97, 0.78);
+          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(216, 251, 245, 0.74)),
+          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.18), transparent 10rem);
+        box-shadow:
+          inset 4px 0 0 rgba(255, 152, 97, 0.78),
+          0 16px 34px rgba(7, 84, 93, 0.08);
       }
 
       .contact-direct span {
@@ -906,20 +907,23 @@
         display: inline-flex;
         align-items: center;
         max-width: 100%;
-        min-height: 2.65rem;
-        padding: 0.62rem 0.82rem;
-        border-radius: 0.7rem;
-        background: rgba(7, 84, 93, 0.09);
+        min-height: 2.8rem;
+        padding: 0.68rem 0.9rem;
+        border: 1px solid rgba(7, 84, 93, 0.1);
+        border-radius: 0.8rem;
+        background: rgba(255, 255, 255, 0.74);
         color: var(--brand-deep);
         font-weight: 800;
         overflow-wrap: anywhere;
+        box-shadow: 0 8px 18px rgba(7, 84, 93, 0.06);
       }
 
       .contact-direct a:hover,
       .contact-direct a:focus-visible {
-        background: rgba(0, 167, 179, 0.16);
-        outline: 2px solid rgba(0, 167, 179, 0.25);
-        outline-offset: 2px;
+        background: rgba(216, 251, 245, 0.86);
+        border-color: rgba(0, 167, 179, 0.24);
+        outline: 3px solid rgba(255, 152, 97, 0.36);
+        outline-offset: 3px;
       }
 
       .sub-item,
@@ -1009,10 +1013,11 @@
         align-content: start;
         position: sticky;
         top: 6.25rem;
-        overflow: hidden;
-        background:
-          linear-gradient(155deg, rgba(255, 255, 255, 0.94), rgba(221, 251, 240, 0.72)),
-          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.2), transparent 12rem);
+        padding: 0;
+        border-color: transparent;
+        background: transparent;
+        box-shadow: none;
+        backdrop-filter: none;
       }
 
       .contact-form {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1347,8 +1347,12 @@
         }
 
         .stream-tabs {
-          grid-template-columns: repeat(2, minmax(0, 1fr));
-          gap: 0.55rem;
+          grid-template-columns: repeat(4, minmax(8.8rem, 1fr));
+          gap: 0.45rem;
+          overflow-x: auto;
+          overscroll-behavior-x: contain;
+          scroll-snap-type: x mandatory;
+          scrollbar-width: none;
           padding: 0.55rem;
           border-radius: 1.15rem;
           position: sticky;
@@ -1359,6 +1363,10 @@
             radial-gradient(circle at 0 0, rgba(183, 242, 234, 0.56), transparent 12rem);
           box-shadow: 0 18px 38px rgba(7, 84, 93, 0.12);
           backdrop-filter: blur(16px);
+        }
+
+        .stream-tabs::-webkit-scrollbar {
+          display: none;
         }
 
         .stream-mobile-summary {
@@ -1391,12 +1399,13 @@
         }
 
         .stream-tab {
-          min-height: 4.25rem;
-          padding: 0.85rem 0.75rem;
+          min-height: 3.65rem;
+          padding: 0.78rem 0.8rem;
           text-align: center;
           border-radius: 0.9rem;
           display: grid;
           place-items: center;
+          scroll-snap-align: start;
           box-shadow: none;
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -379,12 +379,18 @@
         border: 1px solid transparent;
         font-weight: 700;
         cursor: pointer;
-        transition: transform 180ms ease, background 180ms ease, border-color 180ms ease;
+        box-shadow: 0 10px 22px rgba(7, 84, 93, 0.08);
+        transition:
+          transform 180ms ease,
+          background 180ms ease,
+          border-color 180ms ease,
+          box-shadow 180ms ease;
       }
 
       .button:hover,
       .button:focus-visible {
         transform: translateY(-1px);
+        box-shadow: 0 16px 30px rgba(7, 84, 93, 0.12);
       }
 
       .button:focus-visible {
@@ -392,9 +398,21 @@
         outline-offset: 3px;
       }
 
+      .button:active {
+        transform: translateY(0);
+        box-shadow: 0 8px 18px rgba(7, 84, 93, 0.1);
+      }
+
       .button.primary {
         background: linear-gradient(135deg, var(--brand-deep), var(--brand));
         color: #fff;
+        box-shadow: 0 14px 30px rgba(0, 126, 139, 0.2);
+      }
+
+      .button.primary:hover,
+      .button.primary:focus-visible {
+        background: linear-gradient(135deg, #064852, #00b5bf);
+        box-shadow: 0 18px 36px rgba(0, 126, 139, 0.24);
       }
 
       .button.primary:disabled {
@@ -407,8 +425,15 @@
       }
 
       .button.secondary {
-        background: rgba(255, 255, 255, 0.64);
-        border-color: var(--line);
+        background: rgba(255, 255, 255, 0.78);
+        border-color: rgba(0, 126, 139, 0.14);
+        color: var(--brand-deep);
+      }
+
+      .button.secondary:hover,
+      .button.secondary:focus-visible {
+        background: rgba(255, 255, 255, 0.94);
+        border-color: rgba(0, 167, 179, 0.3);
       }
 
       main section {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1204,6 +1204,14 @@
           padding: 2.9rem 0;
         }
 
+        .hero {
+          padding-top: 2.1rem;
+        }
+
+        .hero-copy {
+          padding: 0;
+        }
+
         .site-header .shell {
           min-height: 70px;
         }
@@ -1241,6 +1249,20 @@
 
         .hero-actions .button {
           width: 100%;
+        }
+
+        .hero-proof {
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.6rem;
+        }
+
+        .hero-proof span {
+          display: grid;
+          min-height: 3.25rem;
+          place-items: center;
+          text-align: center;
+          line-height: 1.25;
         }
 
         .footer-bar,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1297,6 +1297,24 @@
           line-height: 1.25;
         }
 
+        .metric-row {
+          gap: 0.7rem;
+          margin-top: 1.5rem;
+        }
+
+        .metric-card {
+          min-height: auto;
+          padding: 1rem;
+        }
+
+        .metric-card b {
+          font-size: 1.18rem;
+        }
+
+        .metric-card span {
+          line-height: 1.5;
+        }
+
         .footer-bar,
         .footer-links {
           justify-content: flex-start;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1352,8 +1352,9 @@
           overflow-x: auto;
           overscroll-behavior-x: contain;
           scroll-snap-type: x mandatory;
-          scrollbar-width: none;
-          padding: 0.55rem;
+          scrollbar-color: rgba(0, 167, 179, 0.52) rgba(7, 84, 93, 0.08);
+          scrollbar-width: thin;
+          padding: 0.55rem 0.55rem 0.75rem;
           border-radius: 1.15rem;
           position: sticky;
           top: 5rem;
@@ -1366,7 +1367,17 @@
         }
 
         .stream-tabs::-webkit-scrollbar {
-          display: none;
+          height: 0.45rem;
+        }
+
+        .stream-tabs::-webkit-scrollbar-track {
+          border-radius: 999px;
+          background: rgba(7, 84, 93, 0.08);
+        }
+
+        .stream-tabs::-webkit-scrollbar-thumb {
+          border-radius: 999px;
+          background: linear-gradient(90deg, rgba(0, 167, 179, 0.62), rgba(255, 152, 97, 0.7));
         }
 
         .stream-mobile-summary {
@@ -1425,6 +1436,7 @@
           background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(216, 251, 245, 0.78));
           box-shadow:
             inset 0 0 0 1px rgba(0, 167, 179, 0.22),
+            inset 0 -4px 0 rgba(255, 152, 97, 0.7),
             0 12px 24px rgba(7, 84, 93, 0.1);
         }
 


### PR DESCRIPTION
This PR tracks rolling visual UX-only improvements from the `ux-only` branch.

Summary:
- Refines the hero call-to-action button states with clearer depth, hover, focus, and active styling.
- Keeps the change CSS-only and static-site compatible under `docs/`.
- Preserves existing public-facing wording, navigation labels, content sections, and the protected homepage accent line.

Screenshots:
- Before: not captured. In-app browser control was unavailable in this session, local Chrome/Edge headless screenshot capture exited before producing an image, Quick Look failed under sandbox initialization, and Computer Use timed out reading Safari.
- After: not captured for the same reason.

Validation:
- `curl -I http://127.0.0.1:4173/` returned `200 OK` from `docs/` served as the web root.
- `python3` HTMLParser parse of `docs/index.html` completed successfully.
- `git diff --check`
- `php -l docs/contact.php`
- Confirmed protected homepage line remains unchanged: "Built around outcomes, usability, and long-term maintainability."