### PR TITLE
Rolling UX updates

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -671,6 +671,10 @@
         gap: 1rem;
         align-self: stretch;
         align-content: start;
+        border-color: rgba(0, 126, 139, 0.14);
+        box-shadow:
+          0 24px 58px rgba(7, 84, 93, 0.13),
+          inset 0 1px 0 rgba(255, 255, 255, 0.92);
       }
 
       .hero-board > * {
@@ -704,7 +708,7 @@
 
       .delivery-list {
         display: grid;
-        gap: 0.7rem;
+        gap: 0.78rem;
       }
 
       .delivery-item {
@@ -712,14 +716,19 @@
         grid-template-columns: 2.7rem minmax(0, 1fr);
         gap: 0.95rem;
         align-items: start;
-        padding: 0.9rem;
-        border: 1px solid rgba(19, 49, 56, 0.07);
+        padding: 0.95rem;
+        border: 1px solid rgba(0, 126, 139, 0.12);
         border-radius: 1rem;
-        background: rgba(255, 255, 255, 0.62);
+        background:
+          linear-gradient(145deg, rgba(255, 255, 255, 0.82), rgba(247, 253, 250, 0.68)),
+          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.1), transparent 7rem);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.78),
+          0 8px 20px rgba(7, 84, 93, 0.045);
       }
 
       .delivery-item:first-child {
-        border-top: 1px solid rgba(19, 49, 56, 0.07);
+        border-top: 1px solid rgba(0, 126, 139, 0.12);
       }
 
       .delivery-item .delivery-code {
@@ -728,10 +737,11 @@
         width: 2.2rem;
         height: 2.2rem;
         border-radius: 0.75rem;
-        background: linear-gradient(145deg, rgba(0, 167, 179, 0.18), rgba(244, 151, 108, 0.16));
+        background: linear-gradient(145deg, rgba(0, 167, 179, 0.22), rgba(244, 151, 108, 0.2));
         color: var(--brand-deep);
         font-size: 0.78rem;
         font-weight: 800;
+        box-shadow: inset 0 0 0 1px rgba(0, 126, 139, 0.08);
       }
 
       .delivery-item strong {

--- a/docs/index.html
+++ b/docs/index.html
@@ -961,15 +961,34 @@
       .contact-direct {
         display: grid;
         gap: 0.45rem;
+        position: relative;
+        overflow: hidden;
         padding: clamp(1.1rem, 2vw, 1.35rem);
-        border: 1px solid rgba(0, 167, 179, 0.18);
+        border: 1px solid rgba(0, 126, 139, 0.18);
         border-radius: 1.25rem;
         background:
-          linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(216, 251, 245, 0.74)),
-          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.18), transparent 10rem);
+          linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(229, 251, 246, 0.82)),
+          radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.2), transparent 10rem);
         box-shadow:
-          inset 4px 0 0 rgba(255, 152, 97, 0.78),
-          0 16px 34px rgba(7, 84, 93, 0.08);
+          inset 0 1px 0 rgba(255, 255, 255, 0.88),
+          0 18px 38px rgba(7, 84, 93, 0.09);
+        transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+      }
+
+      .contact-direct::before {
+        content: "";
+        position: absolute;
+        inset: 0 0 auto;
+        height: 5px;
+        background: linear-gradient(90deg, var(--accent), var(--brand));
+      }
+
+      .contact-direct:hover {
+        transform: translateY(-2px);
+        border-color: rgba(0, 167, 179, 0.28);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.9),
+          0 22px 46px rgba(7, 84, 93, 0.12);
       }
 
       .contact-direct span {

--- a/docs/index.html
+++ b/docs/index.html
@@ -250,7 +250,7 @@
         display: inline-flex;
         align-items: center;
         min-height: 2.5rem;
-        padding: 0 0.45rem;
+        padding: 0 0.62rem;
         position: relative;
         color: var(--muted);
         font-size: 0.95rem;
@@ -261,6 +261,11 @@
       .site-header nav a:hover,
       .site-header nav a:focus-visible {
         color: var(--text);
+      }
+
+      .site-header nav a:hover {
+        background: rgba(255, 255, 255, 0.54);
+        box-shadow: inset 0 -3px 0 rgba(255, 152, 97, 0.5);
       }
 
       .site-header nav a:focus-visible {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1024,7 +1024,7 @@
       .pillar-grid {
         display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 1rem;
+        gap: 1.1rem;
       }
 
       .path-card,
@@ -1046,8 +1046,10 @@
       }
 
       .path-card {
+        --path-accent: var(--brand);
+        --path-accent-soft: rgba(0, 167, 179, 0.12);
         display: grid;
-        grid-template-rows: auto auto 1fr auto;
+        grid-template-rows: auto auto minmax(5.5rem, 1fr) auto;
         gap: 0.45rem;
         min-height: 20rem;
         padding: clamp(1.2rem, 2vw, 1.45rem);
@@ -1056,6 +1058,16 @@
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.86),
           0 16px 36px rgba(7, 84, 93, 0.075);
+      }
+
+      .path-card:nth-child(2) {
+        --path-accent: var(--accent);
+        --path-accent-soft: rgba(255, 152, 97, 0.14);
+      }
+
+      .path-card:nth-child(3) {
+        --path-accent: var(--brand-deep);
+        --path-accent-soft: rgba(7, 84, 93, 0.12);
       }
 
       .path-card > * {
@@ -1069,7 +1081,7 @@
         position: absolute;
         inset: 0 0 auto;
         height: 4px;
-        background: linear-gradient(90deg, var(--brand), var(--accent));
+        background: linear-gradient(90deg, var(--path-accent, var(--brand)), var(--accent));
       }
 
       .path-card::after {
@@ -1122,9 +1134,11 @@
         justify-self: start;
         margin-bottom: 0.75rem;
         padding: 0.42rem 0.6rem;
-        border: 1px solid rgba(0, 126, 139, 0.12);
+        border: 1px solid var(--path-accent-soft);
         border-radius: 0.6rem;
-        background: rgba(255, 255, 255, 0.66);
+        background:
+          linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0.58)),
+          linear-gradient(135deg, var(--path-accent-soft), transparent);
         font-style: normal;
         color: var(--brand-deep);
         font-weight: 800;
@@ -1133,10 +1147,15 @@
         font-size: 0.8rem;
       }
 
+      .path-card h3 {
+        line-height: 1.22;
+      }
+
       .path-highlights {
         display: flex;
         flex-wrap: wrap;
         gap: 0.55rem;
+        align-self: end;
         margin-top: 1rem;
         padding-top: 1rem;
         border-top: 1px solid rgba(19, 49, 56, 0.08);
@@ -1145,8 +1164,8 @@
       .path-highlights span {
         padding: 0.5rem 0.65rem;
         border-radius: 0.65rem;
-        border: 1px solid rgba(0, 126, 139, 0.1);
-        background: rgba(255, 255, 255, 0.62);
+        border: 1px solid var(--path-accent-soft);
+        background: rgba(255, 255, 255, 0.72);
         color: var(--brand-deep);
         font-size: 0.82rem;
         font-weight: 800;
@@ -1542,6 +1561,7 @@
         }
 
         .path-card {
+          grid-template-rows: auto auto auto auto;
           min-height: auto;
           padding-right: 4.4rem;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1642,6 +1642,10 @@
           padding-right: 4.4rem;
         }
 
+        .path-grid {
+          grid-template-columns: 1fr;
+        }
+
         .path-card::after {
           top: 1rem;
           right: 1rem;

--- a/docs/index.html
+++ b/docs/index.html
@@ -539,6 +539,23 @@
         margin-top: 1.75rem;
       }
 
+      .hero-actions .button::after {
+        content: "";
+        width: 0.48rem;
+        height: 0.48rem;
+        border-top: 2px solid currentColor;
+        border-right: 2px solid currentColor;
+        transform: rotate(45deg);
+        opacity: 0.78;
+        transition: transform 180ms ease, opacity 180ms ease;
+      }
+
+      .hero-actions .button:hover::after,
+      .hero-actions .button:focus-visible::after {
+        transform: translateX(0.14rem) rotate(45deg);
+        opacity: 1;
+      }
+
       .hero-proof {
         display: flex;
         flex-wrap: wrap;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1481,43 +1481,22 @@
         }
 
         .hero-proof {
-          display: flex;
-          flex-wrap: nowrap;
-          gap: 0.6rem;
-          margin-inline: -1rem;
+          display: grid;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.65rem;
+          margin-inline: 0;
           max-width: none;
-          overflow-x: auto;
-          padding: 0.1rem 1rem 0.45rem;
-          scroll-padding-inline: 1rem;
-          scroll-snap-type: x mandatory;
-          scrollbar-color: rgba(0, 167, 179, 0.52) rgba(7, 84, 93, 0.08);
-          scrollbar-width: thin;
-        }
-
-        .hero-proof::-webkit-scrollbar {
-          height: 0.38rem;
-        }
-
-        .hero-proof::-webkit-scrollbar-track {
-          border-radius: 999px;
-          background: rgba(7, 84, 93, 0.08);
-        }
-
-        .hero-proof::-webkit-scrollbar-thumb {
-          border-radius: 999px;
-          background: linear-gradient(90deg, rgba(0, 167, 179, 0.62), rgba(255, 152, 97, 0.7));
+          padding: 0;
         }
 
         .hero-proof span {
           display: grid;
           grid-template-columns: 1rem minmax(0, 1fr);
-          flex: 0 0 min(78vw, 16rem);
           min-height: 3.25rem;
           align-items: center;
           text-align: left;
           line-height: 1.25;
           padding: 0.72rem 0.78rem;
-          scroll-snap-align: start;
         }
 
         .hero-proof span::before {
@@ -1775,8 +1754,12 @@
       }
 
       @media (max-width: 430px) {
+        .hero-proof {
+          grid-template-columns: 1fr;
+        }
+
         .hero-proof span {
-          flex-basis: min(82vw, 15.5rem);
+          min-height: 3rem;
         }
       }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -344,28 +344,45 @@
         right: 0;
         width: min(22rem, calc(100vw - 2rem));
         display: grid;
-        gap: 0.25rem;
-        padding: 0.75rem;
-        border-radius: 1.25rem;
-        background: rgba(255, 255, 255, 0.98);
-        border: 1px solid var(--line);
-        box-shadow: var(--shadow);
+        gap: 0.4rem;
+        max-height: calc(100vh - 6rem);
+        overflow-y: auto;
+        padding: 0.65rem;
+        border-radius: 1.1rem;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 255, 252, 0.94)),
+          radial-gradient(circle at 100% 0%, rgba(167, 243, 236, 0.54), transparent 10rem);
+        border: 1px solid rgba(0, 126, 139, 0.12);
+        box-shadow: 0 18px 42px rgba(7, 84, 93, 0.14);
         backdrop-filter: blur(16px);
         z-index: 30;
       }
 
       .mobile-nav-panel a {
-        display: block;
-        padding: 0.85rem 0.95rem;
-        border-radius: 0.95rem;
+        display: flex;
+        align-items: center;
+        min-height: 3rem;
+        padding: 0.78rem 0.9rem;
+        border: 1px solid transparent;
+        border-radius: 0.82rem;
+        background: rgba(255, 255, 255, 0.58);
         color: var(--text);
         font-weight: 700;
+        transition:
+          background 180ms ease,
+          border-color 180ms ease,
+          box-shadow 180ms ease,
+          color 180ms ease;
       }
 
       .mobile-nav-panel a:hover,
       .mobile-nav-panel a:focus-visible {
         background: linear-gradient(135deg, rgba(216, 251, 245, 0.86), rgba(255, 248, 242, 0.76));
-        box-shadow: inset 4px 0 0 var(--accent), 0 0 0 2px rgba(0, 167, 179, 0.18);
+        border-color: rgba(0, 167, 179, 0.22);
+        box-shadow:
+          inset 4px 0 0 var(--accent),
+          0 0 0 2px rgba(0, 167, 179, 0.16);
+        color: var(--brand-deep);
         outline: none;
       }
 
@@ -1435,6 +1452,14 @@
         .mobile-nav summary {
           width: 2.85rem;
           height: 2.85rem;
+        }
+
+        .mobile-nav-panel {
+          position: fixed;
+          top: calc(70px + 0.65rem);
+          right: 1rem;
+          left: 1rem;
+          width: auto;
         }
 
         h1 {

--- a/docs/index.html
+++ b/docs/index.html
@@ -694,7 +694,7 @@
       .hero-board {
         display: grid;
         gap: 1rem;
-        align-self: stretch;
+        align-self: start;
         align-content: start;
         background:
           linear-gradient(150deg, rgba(255, 255, 255, 0.985), rgba(237, 252, 248, 0.92)),
@@ -741,15 +741,17 @@
 
       .delivery-list {
         display: grid;
-        gap: 0.78rem;
+        gap: 0.72rem;
       }
 
       .delivery-item {
+        position: relative;
+        overflow: hidden;
         display: grid;
         grid-template-columns: 2.7rem minmax(0, 1fr);
         gap: 0.95rem;
         align-items: start;
-        padding: 0.95rem;
+        padding: 0.9rem 0.95rem 0.9rem 1.05rem;
         border: 1px solid rgba(0, 126, 139, 0.16);
         border-radius: 1rem;
         background:
@@ -758,6 +760,24 @@
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.78),
           0 10px 22px rgba(7, 84, 93, 0.055);
+        transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+      }
+
+      .delivery-item::before {
+        content: "";
+        position: absolute;
+        inset: 0 auto 0 0;
+        width: 3px;
+        background: linear-gradient(180deg, var(--brand), var(--accent));
+        opacity: 0.62;
+      }
+
+      .delivery-item:hover {
+        transform: translateY(-2px);
+        border-color: rgba(0, 167, 179, 0.26);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.86),
+          0 15px 28px rgba(7, 84, 93, 0.08);
       }
 
       .delivery-item:first-child {
@@ -773,6 +793,7 @@
         background: linear-gradient(145deg, rgba(0, 167, 179, 0.22), rgba(244, 151, 108, 0.2));
         color: var(--brand-deep);
         font-size: 0.78rem;
+        font-variant-numeric: tabular-nums;
         font-weight: 800;
         box-shadow: inset 0 0 0 1px rgba(0, 126, 139, 0.08);
       }
@@ -1838,9 +1859,10 @@
         }
 
         .delivery-item {
-          grid-template-columns: 1fr;
-          gap: 0.25rem;
+          grid-template-columns: 2.45rem minmax(0, 1fr);
+          gap: 0.75rem;
           min-height: auto;
+          padding: 0.88rem 0.95rem 0.88rem 1rem;
         }
 
         .glass-card,

--- a/docs/index.html
+++ b/docs/index.html
@@ -643,7 +643,8 @@
         background: linear-gradient(90deg, var(--brand), var(--accent));
       }
 
-      .metric-card:hover {
+      .metric-card:hover,
+      .metric-card:focus-within {
         transform: translateY(-3px);
         box-shadow: 0 18px 38px rgba(7, 84, 93, 0.1);
       }
@@ -789,7 +790,8 @@
         opacity: 0.62;
       }
 
-      .delivery-item:hover {
+      .delivery-item:hover,
+      .delivery-item:focus-within {
         transform: translateY(-2px);
         border-color: rgba(0, 167, 179, 0.26);
         box-shadow:
@@ -1021,7 +1023,8 @@
         background: linear-gradient(90deg, var(--accent), var(--brand));
       }
 
-      .contact-direct:hover {
+      .contact-direct:hover,
+      .contact-direct:focus-within {
         transform: translateY(-2px);
         border-color: rgba(0, 167, 179, 0.28);
         box-shadow:
@@ -1174,12 +1177,15 @@
       }
 
       .path-card:hover,
-      .pillar:hover {
+      .path-card:focus-within,
+      .pillar:hover,
+      .pillar:focus-within {
         transform: translateY(-3px);
         box-shadow: 0 20px 44px rgba(7, 84, 93, 0.11);
       }
 
-      .path-card:hover {
+      .path-card:hover,
+      .path-card:focus-within {
         border-color: rgba(0, 167, 179, 0.26);
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.9),

--- a/docs/index.html
+++ b/docs/index.html
@@ -1687,52 +1687,19 @@
         }
 
         .stream-tabs {
-          grid-template-columns: repeat(4, minmax(8.8rem, 1fr));
-          gap: 0.45rem;
-          overflow-x: auto;
-          overscroll-behavior-x: contain;
-          scroll-padding-inline: 0.75rem;
-          scroll-snap-type: x mandatory;
-          scrollbar-color: rgba(0, 167, 179, 0.52) rgba(7, 84, 93, 0.08);
-          scrollbar-width: thin;
-          padding: 0.65rem 0.75rem 0.85rem;
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+          gap: 0.5rem;
+          overflow: visible;
+          padding: 0.65rem;
           border-radius: 1.15rem;
-          position: sticky;
-          top: 5rem;
+          position: relative;
+          top: auto;
           z-index: 5;
           background:
             linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(250, 255, 252, 0.86)),
             radial-gradient(circle at 0 0, rgba(183, 242, 234, 0.56), transparent 12rem);
           box-shadow: 0 18px 38px rgba(7, 84, 93, 0.12);
           backdrop-filter: blur(16px);
-          -webkit-mask-image: linear-gradient(
-            90deg,
-            transparent 0,
-            #000 1rem,
-            #000 calc(100% - 1rem),
-            transparent 100%
-          );
-          mask-image: linear-gradient(
-            90deg,
-            transparent 0,
-            #000 1rem,
-            #000 calc(100% - 1rem),
-            transparent 100%
-          );
-        }
-
-        .stream-tabs::-webkit-scrollbar {
-          height: 0.45rem;
-        }
-
-        .stream-tabs::-webkit-scrollbar-track {
-          border-radius: 999px;
-          background: rgba(7, 84, 93, 0.08);
-        }
-
-        .stream-tabs::-webkit-scrollbar-thumb {
-          border-radius: 999px;
-          background: linear-gradient(90deg, rgba(0, 167, 179, 0.62), rgba(255, 152, 97, 0.7));
         }
 
         .stream-mobile-summary {
@@ -1771,7 +1738,6 @@
           border-radius: 0.9rem;
           display: grid;
           place-items: center;
-          scroll-snap-align: start;
           box-shadow: none;
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -696,9 +696,12 @@
         gap: 1rem;
         align-self: stretch;
         align-content: start;
-        border-color: rgba(0, 126, 139, 0.14);
+        background:
+          linear-gradient(150deg, rgba(255, 255, 255, 0.985), rgba(237, 252, 248, 0.92)),
+          radial-gradient(circle at 94% 8%, rgba(244, 151, 108, 0.14), transparent 10rem);
+        border-color: rgba(0, 126, 139, 0.2);
         box-shadow:
-          0 24px 58px rgba(7, 84, 93, 0.13),
+          0 26px 64px rgba(7, 84, 93, 0.16),
           inset 0 1px 0 rgba(255, 255, 255, 0.92);
       }
 
@@ -711,6 +714,11 @@
         font-size: 1.45rem;
         letter-spacing: 0;
         margin-bottom: 0.55rem;
+      }
+
+      .hero-board > div:first-child {
+        padding-bottom: 0.9rem;
+        border-bottom: 1px solid rgba(0, 126, 139, 0.12);
       }
 
       .hero-board p,
@@ -742,14 +750,14 @@
         gap: 0.95rem;
         align-items: start;
         padding: 0.95rem;
-        border: 1px solid rgba(0, 126, 139, 0.12);
+        border: 1px solid rgba(0, 126, 139, 0.16);
         border-radius: 1rem;
         background:
-          linear-gradient(145deg, rgba(255, 255, 255, 0.82), rgba(247, 253, 250, 0.68)),
+          linear-gradient(145deg, rgba(255, 255, 255, 0.94), rgba(247, 253, 250, 0.82)),
           radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.1), transparent 7rem);
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.78),
-          0 8px 20px rgba(7, 84, 93, 0.045);
+          0 10px 22px rgba(7, 84, 93, 0.055);
       }
 
       .delivery-item:first-child {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1617,8 +1617,8 @@
         }
 
         h1 {
-          font-size: 2.65rem;
-          max-width: 11ch;
+          font-size: 2.55rem;
+          max-width: 13ch;
         }
 
         .hero-copy p {
@@ -1640,7 +1640,7 @@
         .hero-proof {
           display: grid;
           grid-template-columns: repeat(2, minmax(0, 1fr));
-          gap: 0.65rem;
+          gap: 0.55rem;
           margin: 1rem 0 0;
           max-width: none;
           padding: 0;
@@ -1649,11 +1649,16 @@
         .hero-proof span {
           display: grid;
           grid-template-columns: 1rem minmax(0, 1fr);
-          min-height: 3.25rem;
+          min-height: 3.05rem;
           align-items: center;
           text-align: left;
           line-height: 1.25;
-          padding: 0.72rem 0.78rem;
+          padding: 0.68rem 0.72rem;
+          font-size: 0.82rem;
+          border-color: rgba(0, 126, 139, 0.2);
+          background:
+            linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(245, 251, 248, 0.8)),
+            radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.12), transparent 5.8rem);
         }
 
         .hero-proof span::before {
@@ -1662,7 +1667,7 @@
 
         .metric-row {
           gap: 0.7rem;
-          margin-top: 1.2rem;
+          margin-top: 1rem;
         }
 
         .metric-card {
@@ -1896,6 +1901,11 @@
         .contact-card,
         .contact-form {
           border-radius: 1.25rem;
+        }
+
+        .hero-board {
+          gap: 0.85rem;
+          padding: 1.15rem;
         }
       }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1476,19 +1476,43 @@
         }
 
         .hero-proof {
-          display: grid;
-          grid-template-columns: repeat(2, minmax(0, 1fr));
+          display: flex;
+          flex-wrap: nowrap;
           gap: 0.6rem;
+          margin-inline: -1rem;
+          max-width: none;
+          overflow-x: auto;
+          padding: 0.1rem 1rem 0.45rem;
+          scroll-padding-inline: 1rem;
+          scroll-snap-type: x mandatory;
+          scrollbar-color: rgba(0, 167, 179, 0.52) rgba(7, 84, 93, 0.08);
+          scrollbar-width: thin;
+        }
+
+        .hero-proof::-webkit-scrollbar {
+          height: 0.38rem;
+        }
+
+        .hero-proof::-webkit-scrollbar-track {
+          border-radius: 999px;
+          background: rgba(7, 84, 93, 0.08);
+        }
+
+        .hero-proof::-webkit-scrollbar-thumb {
+          border-radius: 999px;
+          background: linear-gradient(90deg, rgba(0, 167, 179, 0.62), rgba(255, 152, 97, 0.7));
         }
 
         .hero-proof span {
           display: grid;
           grid-template-columns: 1rem minmax(0, 1fr);
+          flex: 0 0 min(78vw, 16rem);
           min-height: 3.25rem;
           align-items: center;
           text-align: left;
           line-height: 1.25;
           padding: 0.72rem 0.78rem;
+          scroll-snap-align: start;
         }
 
         .hero-proof span::before {
@@ -1746,8 +1770,8 @@
       }
 
       @media (max-width: 430px) {
-        .hero-proof {
-          grid-template-columns: 1fr;
+        .hero-proof span {
+          flex-basis: min(82vw, 15.5rem);
         }
       }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1429,6 +1429,10 @@
           padding-top: 2.1rem;
         }
 
+        .hero-grid {
+          gap: 1.25rem;
+        }
+
         .hero-copy {
           padding: 0;
         }
@@ -1472,8 +1476,16 @@
           max-width: 11ch;
         }
 
+        .hero-copy p {
+          margin-top: 1rem;
+          font-size: 1rem;
+          line-height: 1.64;
+        }
+
         .hero-actions {
           flex-direction: column;
+          gap: 0.72rem;
+          margin-top: 1.35rem;
         }
 
         .hero-actions .button {
@@ -1484,7 +1496,7 @@
           display: grid;
           grid-template-columns: repeat(2, minmax(0, 1fr));
           gap: 0.65rem;
-          margin-inline: 0;
+          margin: 1rem 0 0;
           max-width: none;
           padding: 0;
         }
@@ -1505,7 +1517,7 @@
 
         .metric-row {
           gap: 0.7rem;
-          margin-top: 1.5rem;
+          margin-top: 1.2rem;
         }
 
         .metric-card {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1505,6 +1505,14 @@
           grid-template-columns: 1fr;
         }
 
+        .path-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        .path-card:last-child {
+          grid-column: 1 / -1;
+        }
+
         h1 {
           font-size: 3.7rem;
         }
@@ -1629,6 +1637,7 @@
 
         .path-card {
           grid-template-rows: auto auto auto auto;
+          grid-column: auto;
           min-height: auto;
           padding-right: 4.4rem;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1909,13 +1909,11 @@
         }
       }
 
-      @media (max-width: 380px) {
+      @media (max-width: 420px) {
         .brand-copy small {
           max-width: 8.5rem;
         }
-      }
 
-      @media (max-width: 360px) {
         .hero-proof {
           grid-template-columns: 1fr;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1532,6 +1532,20 @@
           grid-template-columns: repeat(2, minmax(0, 1fr));
         }
 
+        .path-card {
+          padding-right: clamp(1.2rem, 2vw, 1.45rem);
+        }
+
+        .path-card::after {
+          top: auto;
+          right: 1rem;
+          bottom: 1rem;
+          width: 2.8rem;
+          height: 2.8rem;
+          border-radius: 0.85rem;
+          opacity: 0.24;
+        }
+
         .path-card:last-child {
           grid-column: 1 / -1;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1623,6 +1623,20 @@
             radial-gradient(circle at 0 0, rgba(183, 242, 234, 0.56), transparent 12rem);
           box-shadow: 0 18px 38px rgba(7, 84, 93, 0.12);
           backdrop-filter: blur(16px);
+          -webkit-mask-image: linear-gradient(
+            90deg,
+            transparent 0,
+            #000 1rem,
+            #000 calc(100% - 1rem),
+            transparent 100%
+          );
+          mask-image: linear-gradient(
+            90deg,
+            transparent 0,
+            #000 1rem,
+            #000 calc(100% - 1rem),
+            transparent 100%
+          );
         }
 
         .stream-tabs::-webkit-scrollbar {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1304,6 +1304,33 @@
           0 12px 26px rgba(7, 84, 93, 0.08);
       }
 
+      .field input:user-invalid,
+      .field textarea:user-invalid,
+      .field select:user-invalid,
+      .contact-form.is-validated .field input:invalid,
+      .contact-form.is-validated .field textarea:invalid,
+      .contact-form.is-validated .field select:invalid {
+        border-color: rgba(188, 70, 45, 0.56);
+        background:
+          linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(255, 246, 242, 0.86));
+        box-shadow:
+          inset 4px 0 0 rgba(188, 70, 45, 0.62),
+          0 0 0 3px rgba(188, 70, 45, 0.11);
+      }
+
+      .field input:user-invalid:focus-visible,
+      .field textarea:user-invalid:focus-visible,
+      .field select:user-invalid:focus-visible,
+      .contact-form.is-validated .field input:invalid:focus-visible,
+      .contact-form.is-validated .field textarea:invalid:focus-visible,
+      .contact-form.is-validated .field select:invalid:focus-visible {
+        border-color: rgba(188, 70, 45, 0.68);
+        box-shadow:
+          inset 4px 0 0 rgba(188, 70, 45, 0.68),
+          0 0 0 3px rgba(188, 70, 45, 0.14),
+          0 12px 26px rgba(7, 84, 93, 0.08);
+      }
+
       .field input:hover,
       .field textarea:hover,
       .field select:hover {
@@ -2493,9 +2520,12 @@
           event.preventDefault();
 
           if (!contactForm.reportValidity()) {
+            contactForm.classList.add("is-validated");
             formStatus.textContent = "Please complete the required fields.";
             return;
           }
+
+          contactForm.classList.remove("is-validated");
 
           const payload = {
             name: contactForm.name.value.trim(),
@@ -2525,6 +2555,7 @@
               }
 
               contactForm.reset();
+              contactForm.classList.remove("is-validated");
               formStatus.textContent = "Your message has been sent. Thank you.";
             } catch (error) {
               formStatus.textContent =

--- a/docs/index.html
+++ b/docs/index.html
@@ -193,6 +193,7 @@
         display: flex;
         align-items: center;
         gap: 0.9rem;
+        min-width: 0;
         padding: 0.35rem 0.45rem 0.35rem 0.35rem;
         margin-left: -0.35rem;
         border-radius: 1rem;
@@ -221,6 +222,10 @@
         box-shadow: 0 8px 22px rgba(7, 84, 93, 0.18);
         overflow: hidden;
         flex: 0 0 auto;
+      }
+
+      .brand-copy {
+        min-width: 0;
       }
 
       .brand-mark img {
@@ -1582,6 +1587,7 @@
 
         .brand {
           gap: 0.7rem;
+          flex: 1 1 auto;
         }
 
         .brand-mark {
@@ -1591,7 +1597,7 @@
         }
 
         .brand-copy small {
-          max-width: 10.5rem;
+          max-width: 9.5rem;
           font-size: 0.68rem;
           line-height: 1.28;
           letter-spacing: 0.07em;
@@ -1890,6 +1896,12 @@
         .contact-card,
         .contact-form {
           border-radius: 1.25rem;
+        }
+      }
+
+      @media (max-width: 380px) {
+        .brand-copy small {
+          max-width: 8.5rem;
         }
       }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1639,7 +1639,7 @@
           grid-template-rows: auto auto auto auto;
           grid-column: auto;
           min-height: auto;
-          padding-right: 4.4rem;
+          padding-right: 1.2rem;
         }
 
         .path-grid {
@@ -1647,11 +1647,13 @@
         }
 
         .path-card::after {
-          top: 1rem;
-          right: 1rem;
-          width: 2.8rem;
-          height: 2.8rem;
-          border-radius: 0.85rem;
+          top: auto;
+          right: 1.05rem;
+          bottom: 1.05rem;
+          width: 2.35rem;
+          height: 2.35rem;
+          border-radius: 0.75rem;
+          opacity: 0.32;
         }
 
         .footer-bar,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1856,7 +1856,7 @@
         }
       }
 
-      @media (max-width: 430px) {
+      @media (max-width: 360px) {
         .hero-proof {
           grid-template-columns: 1fr;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1015,11 +1015,19 @@
       .path-card {
         display: grid;
         grid-template-rows: auto auto 1fr auto;
+        gap: 0.45rem;
         min-height: 20rem;
+        padding: clamp(1.2rem, 2vw, 1.45rem);
+        padding-right: clamp(4.4rem, 8vw, 5.25rem);
         border-color: rgba(0, 126, 139, 0.14);
         box-shadow:
           inset 0 1px 0 rgba(255, 255, 255, 0.86),
           0 16px 36px rgba(7, 84, 93, 0.075);
+      }
+
+      .path-card > * {
+        position: relative;
+        z-index: 1;
       }
 
       .path-card::before,
@@ -1029,6 +1037,38 @@
         inset: 0 0 auto;
         height: 4px;
         background: linear-gradient(90deg, var(--brand), var(--accent));
+      }
+
+      .path-card::after {
+        content: "";
+        position: absolute;
+        top: 1.05rem;
+        right: 1.05rem;
+        width: 3.35rem;
+        height: 3.35rem;
+        border-radius: 1rem;
+        background:
+          linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.18)),
+          conic-gradient(from 135deg, rgba(0, 167, 179, 0.88), rgba(255, 152, 97, 0.78), rgba(0, 167, 179, 0.88));
+        box-shadow:
+          inset 0 0 0 1px rgba(255, 255, 255, 0.58),
+          0 14px 28px rgba(7, 84, 93, 0.12);
+        opacity: 0.86;
+        transform: rotate(8deg);
+      }
+
+      .path-card:nth-child(2)::after {
+        background:
+          linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.18)),
+          conic-gradient(from 155deg, rgba(255, 152, 97, 0.82), rgba(7, 84, 93, 0.74), rgba(255, 152, 97, 0.82));
+        transform: rotate(-7deg);
+      }
+
+      .path-card:nth-child(3)::after {
+        background:
+          linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.18)),
+          conic-gradient(from 115deg, rgba(7, 84, 93, 0.84), rgba(0, 167, 179, 0.78), rgba(255, 152, 97, 0.74), rgba(7, 84, 93, 0.84));
+        transform: rotate(5deg);
       }
 
       .path-card:hover,
@@ -1445,6 +1485,15 @@
 
         .path-card {
           min-height: auto;
+          padding-right: 4.4rem;
+        }
+
+        .path-card::after {
+          top: 1rem;
+          right: 1rem;
+          width: 2.8rem;
+          height: 2.8rem;
+          border-radius: 0.85rem;
         }
 
         .footer-bar,

--- a/docs/index.html
+++ b/docs/index.html
@@ -1012,6 +1012,16 @@
           radial-gradient(circle at 100% 0%, rgba(255, 152, 97, 0.12), transparent 9rem);
       }
 
+      .path-card {
+        display: grid;
+        grid-template-rows: auto auto 1fr auto;
+        min-height: 20rem;
+        border-color: rgba(0, 126, 139, 0.14);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.86),
+          0 16px 36px rgba(7, 84, 93, 0.075);
+      }
+
       .path-card::before,
       .pillar::before {
         content: "";
@@ -1027,9 +1037,21 @@
         box-shadow: 0 20px 44px rgba(7, 84, 93, 0.11);
       }
 
+      .path-card:hover {
+        border-color: rgba(0, 167, 179, 0.26);
+        box-shadow:
+          inset 0 1px 0 rgba(255, 255, 255, 0.9),
+          0 22px 50px rgba(7, 84, 93, 0.12);
+      }
+
       .path-card em {
         display: inline-block;
+        justify-self: start;
         margin-bottom: 0.75rem;
+        padding: 0.42rem 0.6rem;
+        border: 1px solid rgba(0, 126, 139, 0.12);
+        border-radius: 0.6rem;
+        background: rgba(255, 255, 255, 0.66);
         font-style: normal;
         color: var(--brand-deep);
         font-weight: 800;
@@ -1050,7 +1072,8 @@
       .path-highlights span {
         padding: 0.5rem 0.65rem;
         border-radius: 0.65rem;
-        background: rgba(0, 167, 179, 0.1);
+        border: 1px solid rgba(0, 126, 139, 0.1);
+        background: rgba(255, 255, 255, 0.62);
         color: var(--brand-deep);
         font-size: 0.82rem;
         font-weight: 800;
@@ -1418,6 +1441,10 @@
 
         .metric-card span {
           line-height: 1.5;
+        }
+
+        .path-card {
+          min-height: auto;
         }
 
         .footer-bar,

--- a/docs/index.html
+++ b/docs/index.html
@@ -529,6 +529,7 @@
         display: inline-flex;
         align-items: center;
         gap: 0.48rem;
+        flex: 0 1 auto;
         min-height: 2.85rem;
         padding: 0.6rem 0.82rem;
         border: 1px solid rgba(0, 126, 139, 0.16);
@@ -547,13 +548,15 @@
 
       .hero-proof span::before {
         content: "";
-        width: 0.58rem;
-        height: 0.58rem;
+        width: 1rem;
+        height: 1rem;
         border-radius: 999px;
         flex: 0 0 auto;
-        background: linear-gradient(135deg, var(--brand), var(--accent));
+        background:
+          radial-gradient(circle at 50% 50%, #fff 0 0.17rem, transparent 0.18rem),
+          linear-gradient(135deg, var(--brand), var(--accent));
         box-shadow:
-          0 0 0 4px rgba(0, 167, 179, 0.08),
+          0 0 0 3px rgba(0, 167, 179, 0.08),
           0 0 0 1px rgba(255, 255, 255, 0.9);
       }
 
@@ -1454,11 +1457,13 @@
         }
 
         .hero-proof span {
-          display: flex;
+          display: grid;
+          grid-template-columns: 1rem minmax(0, 1fr);
           min-height: 3.25rem;
           align-items: center;
           text-align: left;
           line-height: 1.25;
+          padding: 0.72rem 0.78rem;
         }
 
         .hero-proof span::before {


### PR DESCRIPTION
This PR tracks rolling visual UX-only improvements from the `ux-only` branch.

Summary:
- Latest update: refines the narrow mobile hero proof-chip layout so the chips switch to a single readable column at common small-phone widths.
- Keeps the change static-site compatible and scoped to `docs/index.html` under the public `docs/` web root.
- Leaves all public wording, sections, navigation labels, metadata, form labels, privacy text, and service descriptions unchanged.
- Leaves the protected homepage line unchanged: "Built around outcomes, usability, and long-term maintainability."

Screenshots:
- Before: not captured. The in-app browser backend was unavailable (`iab` not available), Playwright/Puppeteer are not installed in this checkout, and local Chrome headless exited before writing screenshots in this sandbox.
- After: not captured for the same reasons.

Validation:
- `curl -I http://127.0.0.1:4173/` returned `200 OK` from the `docs/` static web root.
- `git diff --check` passed before commit.
- `git diff --check origin/main...HEAD` passed after push.
- `node --check docs/config.js` passed.
- `php -l docs/contact.php` passed.
- HTML parser check passed for `docs/index.html` and `docs/privacy.html`.
- Marker scan found no tooling or generation markers in `docs/`; existing public service references to "AI Education" remain unchanged.
- Protected-line check confirmed the required homepage line remains present unchanged.

Latest commit:
- `6e9fb5d` Refine mobile hero proof layout